### PR TITLE
Manual install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@ There are basically two ways to build and deploy:
 1. using Docker and Docker Compose; and
 2. installing the dependencies manually in your system.
 
-1\. is the easiest way as it only requires setting up Docker and Docker Compose, while 2\. gives you more control over the system parts and also makes the database persistent by default. However 2\. is trickier to perform, revert the changes and start over when compared to 1\., so we won't provide step by step instructions for it.
+1\. is the easiest way as it only requires setting up Docker and Docker Compose, while 2\. gives you more control over the system parts and also makes the database persistent by default. However 2\. is trickier to perform, revert the changes and start over when compared to 1\..
 
-### Dependencies
+### Docker Compose
+
+#### Dependencies
+
 To build and deploy it's necessary to have in your system
 1. JDK (version 8 or newer)
 1. Maven
 1. Docker
 1. Docker Compose
 
-### Docker Compose
 
 #### Running Biblivre
 
@@ -36,3 +38,47 @@ The following variables are used in Biblivre and can be set on the .env file:
 * `POSTGRES_DB` (database name; default "biblivre4")
 * `DATABASE_HOST_PORT` (database host port; default: 5432)
 * `DATABASE_HOST_NAME` (database hostname; default: "database", which is also the hostname of the container that hosts PostgreSQL)
+
+
+### Manual install (on Debian 10)
+
+#### Dependencies
+
+1. Java Development Kit (JDK)
+1. Maven
+1. Apache Tomcat
+1. PostgreSQL
+1. Git
+
+#### Building and running
+
+1. Install dependencies
+```
+apt install openjdk-11-jdk maven tomcat9 postgresql git
+```
+
+2. Clone the Git repository
+```
+git clone https://github.com/cleydyr/biblivre
+cd biblivre
+```
+
+3. Create the PostgreSQL database
+```
+sudo -u postgres psql < sql/createdatabase.sql
+sudo -u postgres psql biblivre4 < biblivre4.sql
+```
+
+4. Build the .war package
+```
+mvn clean package
+```
+
+5. Install the .war package on Tomcat
+```
+cp target/Biblivre6.war /var/lib/tomcat9/webapps
+```
+
+You can now access Biblivre at ``http://localhost:8080/Biblivre6``. The default
+user is ``admin`` and the default password is ``abracadabra``.
+

--- a/README.md
+++ b/README.md
@@ -49,32 +49,37 @@ The following variables are used in Biblivre and can be set on the .env file:
 1. Apache Tomcat
 1. PostgreSQL
 1. Git
+1. Docker (optional, for running the tests)
 
 #### Building and running
 
-1. Install dependencies
+1. Install dependencies:
 ```
-apt install openjdk-11-jdk maven tomcat9 postgresql git
+apt install openjdk-11-jdk maven tomcat9 postgresql git docker.io
 ```
 
-2. Clone the Git repository
+2. Clone the Git repository:
 ```
 git clone https://github.com/cleydyr/biblivre
 cd biblivre
 ```
 
-3. Create the PostgreSQL database
+3. Create the PostgreSQL database:
 ```
 sudo -u postgres psql < sql/createdatabase.sql
 sudo -u postgres psql biblivre4 < biblivre4.sql
 ```
 
-4. Build the .war package
+4. Build the .war package (note that Docker is required for the tests):
 ```
 mvn clean package
 ```
+Alternatively, to skip the tests:
+```
+mvn clean package -DskipTests
+```
 
-5. Install the .war package on Tomcat
+5. Install the .war package on Tomcat:
 ```
 cp target/Biblivre6.war /var/lib/tomcat9/webapps
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are basically two ways to build and deploy:
 1. using Docker and Docker Compose; and
 2. installing the dependencies manually in your system.
 
-1\. is the easiest way as it only requires setting up Docker and Docker Compose, while 2\. gives you more control over the system parts and also makes the database persistent by default. However 2\. is trickier to perform, revert the changes and start over when compared to 1\..
+1\. is the easiest way as it only requires setting up Docker and Docker Compose, while 2\. gives you more control over the system parts and also makes the database persistent by default. However 2\. is trickier to perform, revert the changes and start over when compared to 1\.
 
 ### Docker Compose
 


### PR DESCRIPTION
This PR adds manual install instructions to the README.

As we can see, Docker is required for the tests introduced in c2f279d, but these can be skipped.