### PR TITLE
ci: cache dart-sass-maven-plugin downloads in GitHub Actions

### DIFF
--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -33,6 +33,13 @@ jobs:
           distribution: "zulu"
           java-version: "25"
           cache: 'maven'
+      - name: Cache Dart Sass downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/dart-sass-maven-plugin
+          key: dart-sass-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            dart-sass-${{ runner.os }}-
       - name: Build with Maven
 
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,12 @@ jobs:
           distribution: "zulu"
           java-version: "25"
           cache: 'maven'
+      - name: Cache Dart Sass downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/dart-sass-maven-plugin
+          key: dart-sass-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            dart-sass-${{ runner.os }}-
       - name: Build with Maven
         run: mvn -B -ntp clean test package -Pgithub-ci

--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
 				<configuration>
 					<outputFolder>src/main/resources/META-INF/resources/static/styles/</outputFolder>
 					<style>COMPRESSED</style>
-					<version>1.83.0</version>
+					<version>1.100.0</version>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
## Summary
- Cache `~/.cache/dart-sass-maven-plugin` in both CI and Docker push workflows so Dart Sass binaries are not re-downloaded on every run
- Bump the pinned Dart Sass version in `pom.xml` from 1.83.0 to 1.100.0

## Test plan
- [x] CI workflow completes successfully on this PR
- [x] Cache step reports a hit on a subsequent run
- [x] Sass compilation still succeeds with version 1.100.0


Made with [Cursor](https://cursor.com)