### PR TITLE
chore(deps): remove unused JNA dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,16 +246,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna</artifactId>
-			<version>5.18.1</version>
-		</dependency>
-		<dependency>
-			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna-platform</artifactId>
-			<version>5.18.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>


### PR DESCRIPTION
## Summary
- Remove direct `jna` and `jna-platform` dependencies from `pom.xml`
- These libraries were declared at compile scope but are not imported or used anywhere in application code
- JNA remains available at test scope via Testcontainers, which is expected

## Test plan
- [x] `mvn compile -DskipTests` succeeds locally
- [ ] CI passes


Made with [Cursor](https://cursor.com)