### PR TITLE
ci: speed up GitHub Actions build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           distribution: "zulu"
           java-version: "25"
           cache: 'maven'
+          server-id: ossindex
+          server-username: ${{ secrets.OSSINDEX_USERNAME }}
+          server-password: ${{ secrets.OSSINDEX_TOKEN }}
       - name: Get Yarn version
         id: yarn-version
         run: echo "version=$(grep -oP '(?<=<yarnVersion>)[^<]+' pom.xml)" >> $GITHUB_OUTPUT
@@ -44,6 +47,13 @@ jobs:
           key: frontend-maven-plugin-${{ runner.os }}-${{ steps.yarn-version.outputs.version }}
           restore-keys: |
             frontend-maven-plugin-${{ runner.os }}-
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v5
+        with:
+          path: src/main/spa-frontend/node_modules
+          key: yarn-${{ runner.os }}-${{ hashFiles('src/main/spa-frontend/yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
       - name: Cache Dart Sass downloads
         uses: actions/cache@v5
         with:
@@ -52,4 +62,4 @@ jobs:
           restore-keys: |
             dart-sass-${{ runner.os }}-
       - name: Build with Maven
-        run: mvn -B -ntp clean test package -Pgithub-ci
+        run: mvn -B -ntp clean test -Pgithub-ci

--- a/pom.xml
+++ b/pom.xml
@@ -475,13 +475,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>repackage</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
@@ -786,6 +779,9 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
 							<skipTests>false</skipTests>
+							<parallel>classes</parallel>
+							<threadCount>2</threadCount>
+							<perCoreThreadCount>false</perCoreThreadCount>
 							<argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
## Summary
- Run `mvn clean test` instead of `clean test package` to avoid a double Maven lifecycle and skip WAR/repackage in CI
- Cache `node_modules` keyed on `yarn.lock` to speed up `yarn install`
- Authenticate OSS Index via `OSSINDEX_USERNAME` and `OSSINDEX_TOKEN` GitHub secrets (fixes 401s)
- Remove duplicate `spring-boot-maven-plugin` repackage execution
- Parallelize Surefire in the `github-ci` profile (`parallel=classes`, `threadCount=2`)

## Test plan
- [ ] Add `OSSINDEX_USERNAME` and `OSSINDEX_TOKEN` repository secrets before merging
- [ ] Confirm CI completes successfully on this PR
- [ ] Compare workflow duration against recent runs (~2:30 baseline)

Made with [Cursor](https://cursor.com)