### PR TITLE
feat(spa): exibir subtítulo da biblioteca no cabeçalho e seletor

### DIFF
--- a/src/main/java/biblivre/multi_schema/Handler.java
+++ b/src/main/java/biblivre/multi_schema/Handler.java
@@ -23,10 +23,13 @@ import biblivre.administration.setup.State;
 import biblivre.core.AbstractHandler;
 import biblivre.core.ExtendedRequest;
 import biblivre.core.ExtendedResponse;
+import biblivre.core.SchemaThreadLocal;
+import biblivre.core.configurations.ConfigurationBO;
 import biblivre.core.enums.ActionResult;
 import biblivre.core.schemas.SchemaBO;
 import biblivre.core.schemas.SchemaDTO;
 import biblivre.core.utils.Constants;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +39,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class Handler extends AbstractHandler {
     private SchemaBO schemaBO;
+    private ConfigurationBO configurationBO;
 
     public void create(ExtendedRequest request, ExtendedResponse response) {
 
@@ -134,6 +138,13 @@ public class Handler extends AbstractHandler {
                 JSONObject o = new JSONObject();
                 o.put("schema", dto.getSchema());
                 o.put("name", dto.getName());
+                String subtitle =
+                        SchemaThreadLocal.withSchema(
+                                dto.getSchema(),
+                                () -> configurationBO.getString(Constants.CONFIG_SUBTITLE));
+                if (StringUtils.isNotBlank(subtitle)) {
+                    o.put("subtitle", subtitle);
+                }
                 array.put(o);
             }
             put("data", array);
@@ -146,5 +157,10 @@ public class Handler extends AbstractHandler {
     @Autowired
     public void setSchemaBO(SchemaBO schemaBO) {
         this.schemaBO = schemaBO;
+    }
+
+    @Autowired
+    public void setConfigurationBO(ConfigurationBO configurationBO) {
+        this.configurationBO = configurationBO;
     }
 }

--- a/src/main/spa-frontend/src/AppHeader.tsx
+++ b/src/main/spa-frontend/src/AppHeader.tsx
@@ -20,6 +20,7 @@ import {
 } from './api-helpers/login/hooks'
 import { useSchemasList } from './api-helpers/schema/hooks'
 import { useSchemaQueryParams } from './api-helpers/schema/useSchemaQueryParams'
+import LibraryHeading from './components/LibraryHeading'
 import messages from './messages'
 import SchemaSelectionModal from './SchemaSelectionModal'
 
@@ -61,10 +62,7 @@ const AppHeader: FC<Props> = ({ isDarkMode, setIsDarkMode }) => {
   
   const loggedIn = isLoggedInSession(session)
 
-  const currentLibraryLabel =
-    schemas?.find((s) => s.schema === activeSchemaId)?.name ??
-    activeSchemaId ??
-    null
+  const activeSchema = schemas?.find((s) => s.schema === activeSchemaId)
 
   const handleAuthClick = () => {
     if (loggedIn) {
@@ -99,10 +97,13 @@ const AppHeader: FC<Props> = ({ isDarkMode, setIsDarkMode }) => {
                   gutterSize='xs'
                   responsive={false}
                 >
-                  {currentLibraryLabel ? (
-                    <EuiText css={{ fontWeight: 500 }} size='s'>
-                      {currentLibraryLabel}
-                    </EuiText>
+                  {activeSchema || activeSchemaId ? (
+                    <LibraryHeading
+                      name={activeSchema?.name ?? activeSchemaId}
+                      subtitle={activeSchema?.subtitle}
+                      subtitleMaxWidth='200px'
+                      titleSize='s'
+                    />
                   ) : null}
                   {schemas.length > 1 ? (
                     <EuiButtonEmpty

--- a/src/main/spa-frontend/src/SchemaSelectionModal.tsx
+++ b/src/main/spa-frontend/src/SchemaSelectionModal.tsx
@@ -12,6 +12,8 @@ import {
 import { useEffect, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 
+import LibraryHeading from './components/LibraryHeading'
+
 import type { FC } from 'react'
 
 import type { SchemaListItem } from './api-helpers/types'
@@ -62,7 +64,14 @@ const SchemaSelectionModal: FC<Props> = ({
           name='biblivre-schema'
           options={schemas.map((s) => ({
             id: s.schema,
-            label: `${s.name} (${s.schema})`,
+            label: (
+              <LibraryHeading
+                name={`${s.name} (${s.schema})`}
+                subtitle={s.subtitle}
+                subtitleMaxWidth='100%'
+                titleSize='s'
+              />
+            ),
             value: s.schema,
           }))}
           onChange={(id) => setSelectedId(id)}

--- a/src/main/spa-frontend/src/api-helpers/types.ts
+++ b/src/main/spa-frontend/src/api-helpers/types.ts
@@ -77,6 +77,7 @@ export type SuccessfulResponse = {
 export type SchemaListItem = {
   schema: string
   name: string
+  subtitle?: string
 }
 
 export type SchemasListResponse = SuccessfulResponse & {

--- a/src/main/spa-frontend/src/components/LibraryHeading.test.tsx
+++ b/src/main/spa-frontend/src/components/LibraryHeading.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+import { describe, expect, it } from 'vitest'
+
+import type { ComponentProps } from 'react'
+
+import LibraryHeading from './LibraryHeading'
+
+function renderHeading(props: ComponentProps<typeof LibraryHeading>) {
+  return render(
+    <IntlProvider locale='pt-BR' messages={{}}>
+      <LibraryHeading {...props} />
+    </IntlProvider>,
+  )
+}
+
+describe('LibraryHeading', () => {
+  it('renders the library name', () => {
+    renderHeading({ name: 'Biblioteca Central' })
+
+    expect(screen.getByText('Biblioteca Central')).toBeInTheDocument()
+  })
+
+  it('renders the subtitle when provided', () => {
+    renderHeading({
+      name: 'Biblioteca Central',
+      subtitle: 'Rede Comunitária',
+    })
+
+    expect(screen.getByText('Rede Comunitária')).toBeInTheDocument()
+  })
+
+  it('omits empty subtitles', () => {
+    renderHeading({
+      name: 'Biblioteca Central',
+      subtitle: '   ',
+    })
+
+    expect(screen.queryByTitle('   ')).not.toBeInTheDocument()
+  })
+
+  it('exposes the full subtitle on hover via title attribute', () => {
+    renderHeading({
+      name: 'Biblioteca Central',
+      subtitle: 'Um subtítulo longo que será truncado visualmente no cabeçalho',
+    })
+
+    expect(
+      screen.getByTitle(
+        'Um subtítulo longo que será truncado visualmente no cabeçalho',
+      ),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/main/spa-frontend/src/components/LibraryHeading.tsx
+++ b/src/main/spa-frontend/src/components/LibraryHeading.tsx
@@ -1,0 +1,49 @@
+import { EuiText, useEuiTheme } from '@elastic/eui'
+
+import type { CSSProperties, FC, ReactNode } from 'react'
+
+type Props = {
+  name: ReactNode
+  subtitle?: string | null
+  /** Max width before the subtitle truncates with ellipsis. */
+  subtitleMaxWidth?: CSSProperties['maxWidth']
+  titleSize?: 'xs' | 's' | 'm'
+}
+
+const LibraryHeading: FC<Props> = ({
+  name,
+  subtitle,
+  subtitleMaxWidth = '240px',
+  titleSize = 's',
+}) => {
+  const { euiTheme } = useEuiTheme()
+  const trimmedSubtitle = subtitle?.trim()
+
+  return (
+    <div css={{ minWidth: 0, maxWidth: subtitleMaxWidth }}>
+      <EuiText css={{ fontWeight: euiTheme.font.weight.semiBold }} size={titleSize}>
+        {name}
+      </EuiText>
+      {trimmedSubtitle ? (
+        <EuiText
+          css={{
+            color: euiTheme.colors.textSubdued,
+            fontSize: euiTheme.size.s,
+            lineHeight: euiTheme.font.lineHeightMultiplier,
+            marginTop: euiTheme.size.xxs,
+            maxWidth: subtitleMaxWidth,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          size='xs'
+          title={trimmedSubtitle}
+        >
+          {trimmedSubtitle}
+        </EuiText>
+      ) : null}
+    </div>
+  )
+}
+
+export default LibraryHeading


### PR DESCRIPTION
## Summary
- Expõe `general.subtitle` na API `multi_schema.list` para cada biblioteca ativa.
- Adiciona o componente `LibraryHeading` com tipografia hierárquica (título + subtítulo em cor subdued) e truncamento via ellipsis, com tooltip nativo (`title`) para o texto completo.
- Usa `LibraryHeading` no cabeçalho do SPA e nas opções do modal de seleção de biblioteca.

## Test plan
- [ ] Configurar subtítulo em uma biblioteca via interface clássica (Administração → Configurações → Subtítulo da biblioteca).
- [ ] Abrir o SPA e confirmar que o cabeçalho exibe título + subtítulo; subtítulos longos devem truncar com reticências e mostrar o texto completo ao passar o mouse.
- [ ] Com múltiplas bibliotecas, abrir "Escolher biblioteca" e verificar subtítulo abaixo de cada opção.
- [ ] Biblioteca sem subtítulo configurado deve exibir apenas o título, sem espaço extra.
- [ ] `yarn test:run src/components/LibraryHeading.test.tsx`


Made with [Cursor](https://cursor.com)