### PR TITLE
Remove unused spring-plugin-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,12 +335,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.plugin</groupId>
-			<artifactId>spring-plugin-core</artifactId>
-			<version>4.0.0</version>
-		</dependency>
-
-		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
 			<artifactId>swagger-annotations</artifactId>
 			<version>2.2.52</version>


### PR DESCRIPTION
## Summary
- Remove the explicit `spring-plugin-core:4.0.0` dependency from `pom.xml`
- The artifact is not managed by Spring Boot's BOM and is no longer required transitively by Spring Data Commons or other project dependencies

## Test plan
- [x] `mvn dependency:tree -Dincludes=org.springframework.plugin` shows no matches
- [x] `mvn compile -Dmaven.test.skip=true` succeeds
