### PR TITLE
Reduce Metaspace and classpath by replacing JPA with JDBC for reports.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,16 @@
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
 			<version>6.21.5</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.jfree</groupId>
+					<artifactId>jfreechart</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jfree</groupId>
+					<artifactId>jcommon</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- Skip CVE-2025-48734 -->
 		<dependency>
@@ -267,16 +277,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -430,7 +435,7 @@
 					<authId>ossindex</authId>
 					<excludeVulnerabilityIds>
 						<excludeVulnerabilityId>CVE-2023-52070</excludeVulnerabilityId>
-						<!-- Disputed JFreeChart finding via jasperreports -->
+						<!-- Disputed finding reported against jasperreports; no community fix as of 6.21.5 -->
 						<excludeVulnerabilityId>CVE-2025-10492</excludeVulnerabilityId>
 						<!-- No community fix for jasperreports as of 6.21.5 -->
 						<excludeVulnerabilityId>CVE-2026-6009</excludeVulnerabilityId>
@@ -445,6 +450,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludeDevtools>true</excludeDevtools>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
@@ -653,6 +661,13 @@
 	<profiles>
 		<profile>
 			<id>developer</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-devtools</artifactId>
+					<optional>true</optional>
+				</dependency>
+			</dependencies>
 			<build>
 				<plugins>
 					<plugin>

--- a/src/main/java/biblivre/administration/reports/v2/model/Report.java
+++ b/src/main/java/biblivre/administration/reports/v2/model/Report.java
@@ -1,30 +1,23 @@
 package biblivre.administration.reports.v2.model;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import jakarta.persistence.*;
 import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
-@Entity
-@Table(schema = "global")
 @Getter
 @AllArgsConstructor
 public class Report {
     public Report() {}
 
-    @GeneratedValue @Id long id;
+    @Setter long id;
 
     String name;
 
     String description;
 
-    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL)
-    @JsonManagedReference
     Collection<ReportParameter> parameters;
 
-    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL)
-    @JsonManagedReference
     Collection<ReportFill> fills;
 
     String schema;

--- a/src/main/java/biblivre/administration/reports/v2/model/ReportFill.java
+++ b/src/main/java/biblivre/administration/reports/v2/model/ReportFill.java
@@ -1,34 +1,20 @@
 package biblivre.administration.reports.v2.model;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import jakarta.persistence.*;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-@Entity
-@Table(schema = "global")
 @Getter
 @AllArgsConstructor
 public class ReportFill {
     public ReportFill() {}
 
-    @GeneratedValue @Id long id;
+    @Setter long id;
 
-    @ElementCollection
-    @CollectionTable(
-            name = "report_fill_parameters",
-            joinColumns = @JoinColumn(name = "report_fill_id"))
-    @MapKeyColumn(name = "parameter_name")
-    @Column(name = "parameter_value")
     Map<String, String> fillParameters;
 
-    @ManyToOne
-    @JoinColumn(name = "report_id", nullable = false)
-    @JsonBackReference
-    @Setter
-    Report report;
+    @Setter Report report;
 
     int digitalMediaId;
 }

--- a/src/main/java/biblivre/administration/reports/v2/model/ReportParameter.java
+++ b/src/main/java/biblivre/administration/reports/v2/model/ReportParameter.java
@@ -1,20 +1,19 @@
 package biblivre.administration.reports.v2.model;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * A report parameter is a parameter that is used to generate a report. It contains a name and a
  * type.
  */
-@Entity
-@Table(name = "report_parameters", schema = "global")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class ReportParameter {
-    @GeneratedValue @Id long id;
+    @Setter long id;
 
     String name;
 
@@ -22,9 +21,5 @@ public class ReportParameter {
 
     String description;
 
-    @ManyToOne
-    @JoinColumn(name = "report_id", nullable = false)
-    @JsonBackReference
-    @Setter
-    Report report;
+    @Setter Report report;
 }

--- a/src/main/java/biblivre/administration/reports/v2/persistence/ReportFillRepository.java
+++ b/src/main/java/biblivre/administration/reports/v2/persistence/ReportFillRepository.java
@@ -1,6 +1,7 @@
 package biblivre.administration.reports.v2.persistence;
 
 import biblivre.administration.reports.v2.model.ReportFill;
-import org.springframework.data.repository.CrudRepository;
 
-public interface ReportFillRepository extends CrudRepository<ReportFill, Long> {}
+public interface ReportFillRepository {
+    ReportFill save(ReportFill reportFill);
+}

--- a/src/main/java/biblivre/administration/reports/v2/persistence/ReportFillRepositoryImpl.java
+++ b/src/main/java/biblivre/administration/reports/v2/persistence/ReportFillRepositoryImpl.java
@@ -1,0 +1,70 @@
+package biblivre.administration.reports.v2.persistence;
+
+import biblivre.administration.reports.v2.model.ReportFill;
+import biblivre.core.AbstractDAO;
+import biblivre.core.exceptions.DAOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReportFillRepositoryImpl extends AbstractDAO implements ReportFillRepository {
+
+    @Override
+    public ReportFill save(ReportFill reportFill) {
+        return withTransactionContext(
+                connection -> {
+                    insertFill(connection, reportFill);
+                    insertFillParameters(connection, reportFill);
+                    return reportFill;
+                });
+    }
+
+    private static void insertFill(Connection connection, ReportFill reportFill) throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        """
+                        INSERT INTO global.report_fill (report_id, digital_media_id)
+                        VALUES (?, ?)
+                        """,
+                        Statement.RETURN_GENERATED_KEYS)) {
+            pst.setLong(1, reportFill.getReport().getId());
+            pst.setInt(2, reportFill.getDigitalMediaId());
+            pst.executeUpdate();
+
+            try (ResultSet keys = pst.getGeneratedKeys()) {
+                if (!keys.next()) {
+                    throw new DAOException(new Exception("Missing generated report fill id"));
+                }
+                reportFill.setId(keys.getLong(1));
+            }
+        }
+    }
+
+    private static void insertFillParameters(Connection connection, ReportFill reportFill)
+            throws Exception {
+        Map<String, String> parameters = reportFill.getFillParameters();
+        if (parameters == null || parameters.isEmpty()) {
+            return;
+        }
+
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        """
+                        INSERT INTO global.report_fill_parameters
+                            (report_fill_id, parameter_name, parameter_value)
+                        VALUES (?, ?, ?)
+                        """)) {
+            for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                pst.setLong(1, reportFill.getId());
+                pst.setString(2, entry.getKey());
+                pst.setString(3, entry.getValue());
+                pst.addBatch();
+            }
+            pst.executeBatch();
+        }
+    }
+}

--- a/src/main/java/biblivre/administration/reports/v2/persistence/ReportParameterRepository.java
+++ b/src/main/java/biblivre/administration/reports/v2/persistence/ReportParameterRepository.java
@@ -1,6 +1,0 @@
-package biblivre.administration.reports.v2.persistence;
-
-import biblivre.administration.reports.v2.model.ReportParameter;
-import org.springframework.data.repository.CrudRepository;
-
-public interface ReportParameterRepository extends CrudRepository<ReportParameter, Long> {}

--- a/src/main/java/biblivre/administration/reports/v2/persistence/ReportRepository.java
+++ b/src/main/java/biblivre/administration/reports/v2/persistence/ReportRepository.java
@@ -3,14 +3,17 @@ package biblivre.administration.reports.v2.persistence;
 import biblivre.administration.reports.v2.model.Report;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 
-public interface ReportRepository extends CrudRepository<Report, Long> {
-    @Query("SELECT DISTINCT r FROM Report r LEFT JOIN FETCH r.parameters")
+public interface ReportRepository {
+    Report save(Report report);
+
     List<Report> findAllWithParameters();
 
-    @Query("SELECT DISTINCT r FROM Report r LEFT JOIN FETCH r.parameters WHERE r.id = :id")
-    Optional<Report> findByIdWithParameters(@Param("id") Long id);
+    Optional<Report> findByIdWithParameters(Long id);
+
+    Optional<Report> findById(Long id);
+
+    void deleteById(Long id);
+
+    void deleteAll();
 }

--- a/src/main/java/biblivre/administration/reports/v2/persistence/ReportRepositoryImpl.java
+++ b/src/main/java/biblivre/administration/reports/v2/persistence/ReportRepositoryImpl.java
@@ -1,0 +1,278 @@
+package biblivre.administration.reports.v2.persistence;
+
+import biblivre.administration.reports.v2.model.Report;
+import biblivre.administration.reports.v2.model.ReportParameter;
+import biblivre.core.AbstractDAO;
+import biblivre.core.exceptions.DAOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReportRepositoryImpl extends AbstractDAO implements ReportRepository {
+
+    @Override
+    public Report save(Report report) {
+        return withTransactionContext(
+                connection -> {
+                    if (report.getId() == 0) {
+                        return insert(connection, report);
+                    }
+                    return update(connection, report);
+                });
+    }
+
+    private Report insert(Connection connection, Report report) throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        """
+                        INSERT INTO global.report (name, description, schema, digital_media_id)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        Statement.RETURN_GENERATED_KEYS)) {
+            pst.setString(1, report.getName());
+            pst.setString(2, report.getDescription());
+            pst.setString(3, report.getSchema());
+            pst.setLong(4, report.getDigitalMediaId());
+            pst.executeUpdate();
+
+            try (ResultSet keys = pst.getGeneratedKeys()) {
+                if (!keys.next()) {
+                    throw new DAOException(new Exception("Missing generated report id"));
+                }
+                report.setId(keys.getLong(1));
+            }
+        }
+
+        if (report.getParameters() != null) {
+            for (ReportParameter parameter : report.getParameters()) {
+                parameter.setReport(report);
+                insertParameter(connection, parameter);
+            }
+        }
+
+        return report;
+    }
+
+    private Report update(Connection connection, Report report) throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        """
+                        UPDATE global.report
+                        SET name = ?, description = ?, schema = ?, digital_media_id = ?
+                        WHERE id = ?
+                        """)) {
+            pst.setString(1, report.getName());
+            pst.setString(2, report.getDescription());
+            pst.setString(3, report.getSchema());
+            pst.setLong(4, report.getDigitalMediaId());
+            pst.setLong(5, report.getId());
+            pst.executeUpdate();
+        }
+        return report;
+    }
+
+    private void insertParameter(Connection connection, ReportParameter parameter)
+            throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        """
+                        INSERT INTO global.report_parameters (name, type, description, report_id)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        Statement.RETURN_GENERATED_KEYS)) {
+            pst.setString(1, parameter.getName());
+            pst.setString(2, parameter.getType());
+            pst.setString(3, parameter.getDescription());
+            pst.setLong(4, parameter.getReport().getId());
+            pst.executeUpdate();
+
+            try (ResultSet keys = pst.getGeneratedKeys()) {
+                if (!keys.next()) {
+                    throw new DAOException(new Exception("Missing generated report parameter id"));
+                }
+                parameter.setId(keys.getLong(1));
+            }
+        }
+    }
+
+    @Override
+    public List<Report> findAllWithParameters() {
+        try (Connection connection = datasource.getConnection();
+                PreparedStatement pst =
+                        connection.prepareStatement(
+                                """
+                                SELECT r.id, r.name, r.description, r.schema, r.digital_media_id,
+                                       p.id AS parameter_id, p.name AS parameter_name,
+                                       p.type AS parameter_type, p.description AS parameter_description
+                                FROM global.report r
+                                LEFT JOIN global.report_parameters p ON p.report_id = r.id
+                                ORDER BY r.id, p.id
+                                """);
+                ResultSet rs = pst.executeQuery()) {
+            return mapReportsWithParameters(rs);
+        } catch (Exception e) {
+            throw new DAOException(e);
+        }
+    }
+
+    @Override
+    public Optional<Report> findByIdWithParameters(Long id) {
+        try (Connection connection = datasource.getConnection();
+                PreparedStatement pst =
+                        connection.prepareStatement(
+                                """
+                                SELECT r.id, r.name, r.description, r.schema, r.digital_media_id,
+                                       p.id AS parameter_id, p.name AS parameter_name,
+                                       p.type AS parameter_type, p.description AS parameter_description
+                                FROM global.report r
+                                LEFT JOIN global.report_parameters p ON p.report_id = r.id
+                                WHERE r.id = ?
+                                ORDER BY p.id
+                                """)) {
+            pst.setLong(1, id);
+            try (ResultSet rs = pst.executeQuery()) {
+                List<Report> reports = mapReportsWithParameters(rs);
+                return reports.stream().findFirst();
+            }
+        } catch (Exception e) {
+            throw new DAOException(e);
+        }
+    }
+
+    @Override
+    public Optional<Report> findById(Long id) {
+        try (Connection connection = datasource.getConnection();
+                PreparedStatement pst =
+                        connection.prepareStatement(
+                                """
+                                SELECT id, name, description, schema, digital_media_id
+                                FROM global.report
+                                WHERE id = ?
+                                """)) {
+            pst.setLong(1, id);
+            try (ResultSet rs = pst.executeQuery()) {
+                if (!rs.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(mapReport(rs, Collections.emptyList()));
+            }
+        } catch (Exception e) {
+            throw new DAOException(e);
+        }
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        withTransactionContext(
+                connection -> {
+                    deleteFillParametersByReportId(connection, id);
+                    deleteFillsByReportId(connection, id);
+                    deleteParametersByReportId(connection, id);
+                    try (PreparedStatement pst =
+                            connection.prepareStatement("DELETE FROM global.report WHERE id = ?")) {
+                        pst.setLong(1, id);
+                        pst.executeUpdate();
+                    }
+                });
+    }
+
+    @Override
+    public void deleteAll() {
+        withTransactionContext(
+                connection -> {
+                    try (Statement statement = connection.createStatement()) {
+                        statement.executeUpdate("DELETE FROM global.report_fill_parameters");
+                        statement.executeUpdate("DELETE FROM global.report_fill");
+                        statement.executeUpdate("DELETE FROM global.report_parameters");
+                        statement.executeUpdate("DELETE FROM global.report");
+                    }
+                });
+    }
+
+    private static void deleteFillParametersByReportId(Connection connection, long reportId)
+            throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        """
+                        DELETE FROM global.report_fill_parameters
+                        WHERE report_fill_id IN (
+                            SELECT id FROM global.report_fill WHERE report_id = ?
+                        )
+                        """)) {
+            pst.setLong(1, reportId);
+            pst.executeUpdate();
+        }
+    }
+
+    private static void deleteFillsByReportId(Connection connection, long reportId)
+            throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement("DELETE FROM global.report_fill WHERE report_id = ?")) {
+            pst.setLong(1, reportId);
+            pst.executeUpdate();
+        }
+    }
+
+    private static void deleteParametersByReportId(Connection connection, long reportId)
+            throws Exception {
+        try (PreparedStatement pst =
+                connection.prepareStatement(
+                        "DELETE FROM global.report_parameters WHERE report_id = ?")) {
+            pst.setLong(1, reportId);
+            pst.executeUpdate();
+        }
+    }
+
+    private static List<Report> mapReportsWithParameters(ResultSet rs) throws Exception {
+        Map<Long, Report> reports = new LinkedHashMap<>();
+
+        while (rs.next()) {
+            long reportId = rs.getLong("id");
+            Report report =
+                    reports.computeIfAbsent(
+                            reportId,
+                            id -> {
+                                try {
+                                    return mapReport(rs, new ArrayList<>());
+                                } catch (Exception e) {
+                                    throw new DAOException(e);
+                                }
+                            });
+
+            long parameterId = rs.getLong("parameter_id");
+            if (!rs.wasNull()) {
+                ReportParameter parameter =
+                        new ReportParameter(
+                                parameterId,
+                                rs.getString("parameter_name"),
+                                rs.getString("parameter_type"),
+                                rs.getString("parameter_description"),
+                                report);
+                report.getParameters().add(parameter);
+            }
+        }
+
+        return new ArrayList<>(reports.values());
+    }
+
+    private static Report mapReport(ResultSet rs, List<ReportParameter> parameters)
+            throws Exception {
+        return new Report(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("description"),
+                parameters,
+                Collections.emptyList(),
+                rs.getString("schema"),
+                rs.getLong("digital_media_id"));
+    }
+}

--- a/src/main/java/biblivre/update/v6_0_0$8_0_0$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$8_0_0$alpha/Update.java
@@ -1,0 +1,61 @@
+package biblivre.update.v6_0_0$8_0_0$alpha;
+
+import biblivre.update.UpdateService;
+import biblivre.update.exception.UpdateException;
+import java.sql.Connection;
+import java.sql.Statement;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Update implements UpdateService {
+
+    @Override
+    public void doUpdate(Connection connection) {
+        createReportTables(connection);
+    }
+
+    private void createReportTables(Connection connection) {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS global.report (
+                        id BIGSERIAL PRIMARY KEY,
+                        name TEXT,
+                        description TEXT,
+                        schema TEXT,
+                        digital_media_id BIGINT NOT NULL
+                    )
+                    """);
+            statement.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS global.report_parameters (
+                        id BIGSERIAL PRIMARY KEY,
+                        name TEXT,
+                        type TEXT,
+                        description TEXT,
+                        report_id BIGINT NOT NULL REFERENCES global.report (id) ON DELETE CASCADE
+                    )
+                    """);
+            statement.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS global.report_fill (
+                        id BIGSERIAL PRIMARY KEY,
+                        report_id BIGINT NOT NULL REFERENCES global.report (id) ON DELETE CASCADE,
+                        digital_media_id INTEGER NOT NULL
+                    )
+                    """);
+            statement.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS global.report_fill_parameters (
+                        report_fill_id BIGINT NOT NULL
+                            REFERENCES global.report_fill (id) ON DELETE CASCADE,
+                        parameter_name TEXT NOT NULL,
+                        parameter_value TEXT,
+                        PRIMARY KEY (report_fill_id, parameter_name)
+                    )
+                    """);
+        } catch (Exception e) {
+            throw new UpdateException("Error creating report tables", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,11 +10,6 @@ spring:
       prefix: /WEB-INF/jsp/
       suffix: .jsp
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-
   devtools:
     livereload:
       enabled: true


### PR DESCRIPTION
Drop Hibernate (only used by three report entities), trim unused Jasper chart deps, and keep spring-boot-devtools behind the developer profile.