### PR TITLE
fix: inject DigitalMediaDAO in RestoreService

### DIFF
--- a/src/main/java/biblivre/administration/backup/RestoreService.java
+++ b/src/main/java/biblivre/administration/backup/RestoreService.java
@@ -122,7 +122,7 @@ public class RestoreService {
 
     private void setPGSearchPath(String schema) throws RestoreException {
         writeLine(
-                        """
+                """
                         SET search_path = "%s", pg_catalog
                         """
                         .formatted(schema));
@@ -183,7 +183,7 @@ public class RestoreService {
 
     public void deleteSchemaFromSchemasTable(String originalSchemaName) throws RestoreException {
         writeLine(
-                        """
+                """
                         DELETE FROM "global".schemas WHERE "schema" = '%s'
                         """
                         .formatted(originalSchemaName));
@@ -195,8 +195,7 @@ public class RestoreService {
     }
 
     private static String buildInsertSchemaQuery(String finalSchemaName, String schemaTitle) {
-        return
-                """
+        return """
                 INSERT INTO "global".schemas (schema, name) VALUES ('%s', E'%s');
                 """
                 .formatted(finalSchemaName, schemaTitle);
@@ -204,7 +203,7 @@ public class RestoreService {
 
     public void dropSchema(String schemaToBeDeleted) throws RestoreException {
         writeLine(
-                        """
+                """
                         DROP SCHEMA "%s" CASCADE
                         """
                         .formatted(schemaToBeDeleted));
@@ -212,7 +211,7 @@ public class RestoreService {
 
     public void deleteAllDigitalMedia(String schemaToBeDeleted) throws RestoreException {
         writeLine(
-                        """
+                """
                         DELETE FROM "%s".digital_media
                         """
                         .formatted(schemaToBeDeleted));
@@ -288,7 +287,7 @@ public class RestoreService {
     private void changePGSchemaName(String originalSchemaName, String finalSchemaName)
             throws RestoreException {
         writeLine(
-                        """
+                """
                         ALTER SCHEMA "%s" RENAME TO "%s"
                         """
                         .formatted(originalSchemaName, finalSchemaName));
@@ -416,5 +415,10 @@ public class RestoreService {
     @Autowired
     public void setDataSource(DataSource datasource) {
         this.datasource = datasource;
+    }
+
+    @Autowired
+    public void setDigitalMediaDAO(DigitalMediaDAO digitalMediaDAO) {
+        this.digitalMediaDAO = digitalMediaDAO;
     }
 }

--- a/src/test/java/biblivre/administration/backup/RestoreServiceTest.java
+++ b/src/test/java/biblivre/administration/backup/RestoreServiceTest.java
@@ -1,0 +1,63 @@
+package biblivre.administration.backup;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import biblivre.administration.setup.State;
+import biblivre.digitalmedia.DigitalMediaDAO;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RestoreServiceTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void setDigitalMediaDAO_isAutowired() throws Exception {
+        Method setter = RestoreService.class.getMethod("setDigitalMediaDAO", DigitalMediaDAO.class);
+
+        assertNotNull(
+                setter.getAnnotation(Autowired.class),
+                "DigitalMediaDAO must be Spring-injected for media restore during backup restore");
+    }
+
+    @Test
+    void processSchemaRestores_importsMediaFilesFromSchemaFolder() throws Exception {
+        DigitalMediaDAO digitalMediaDAO = mock(DigitalMediaDAO.class);
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(digitalMediaDAO.importFile(any(File.class))).thenReturn(42L);
+
+        RestoreService service = new RestoreService();
+        service.setDataSource(dataSource);
+        service.setDigitalMediaDAO(digitalMediaDAO);
+
+        Path schemaDir = Files.createDirectory(tempDir.resolve("single"));
+        Files.writeString(schemaDir.resolve("123_photo.jpg"), "fake-media-content");
+
+        State.start();
+
+        assertDoesNotThrow(() -> service.processSchemaRestores(tempDir.toFile(), "b5b", "single"));
+
+        verify(digitalMediaDAO).importFile(any(File.class));
+        verify(statement)
+                .execute(contains("UPDATE digital_media SET blob = '42' WHERE id = '123'"));
+    }
+}


### PR DESCRIPTION
## Summary
- Restore of Biblivre 5 backups failed with `NullPointerException` when processing media files because `RestoreService.digitalMediaDAO` was never injected.
- Add the missing `@Autowired` setter (same pattern already used for `DataSource`) and a regression test covering media-folder restore.

## Test plan
- [x] `mvn test -P developer -Dtest=RestoreServiceTest`
- [ ] Restore a Biblivre 5 backup that includes digital media files and confirm media processing completes without NPE
- [ ] Confirm restored `digital_media.blob` values point to newly imported OIDs/files


Made with [Cursor](https://cursor.com)