### PR TITLE
fix: resolve lending userSearch NPE from mismatched holding MARC 001

### DIFF
--- a/src/main/java/biblivre/cataloging/RecordDTO.java
+++ b/src/main/java/biblivre/cataloging/RecordDTO.java
@@ -100,8 +100,6 @@ public class RecordDTO extends AbstractDTO {
     public void setId(int id) {
         nullifyDerivedFields();
 
-        this.id = id;
-
         MarcFactory factory = MarcFactory.newInstance();
 
         ControlField field = factory.newControlField("001");
@@ -110,9 +108,14 @@ public class RecordDTO extends AbstractDTO {
 
         field.setData(formatter.format(id));
 
+        for (VariableField existing : List.copyOf(record.getVariableFields("001"))) {
+            record.removeVariableField(existing);
+        }
+
         record.addVariableField(field);
 
         nullifyDerivedFields();
+        this.id = id;
     }
 
     public String getUTF8Iso2709() {

--- a/src/main/java/biblivre/cataloging/holding/HoldingDAOImpl.java
+++ b/src/main/java/biblivre/cataloging/holding/HoldingDAOImpl.java
@@ -129,8 +129,9 @@ public class HoldingDAOImpl extends RecordDAOImpl implements HoldingDAO {
 
             ResultSet rs = pst.executeQuery();
             while (rs.next()) {
+                int id = rs.getInt("id");
                 RecordDTO dto = this.populateDTO(rs);
-                map.put(dto.getId(), dto);
+                map.put(id, dto);
             }
         } catch (Exception e) {
             throw new DAOException(e);
@@ -665,7 +666,7 @@ public class HoldingDAOImpl extends RecordDAOImpl implements HoldingDAO {
 
         try (Connection con = datasource.getConnection()) {
             String sql =
-                            """
+                    """
                         SELECT 0 as indexing_group_id, COUNT(DISTINCT H.id) as total FROM biblio_holdings H
                             INNER JOIN biblio_search_results B ON H.record_id = B.record_id
                             WHERE B.search_id = ?
@@ -814,12 +815,7 @@ public class HoldingDAOImpl extends RecordDAOImpl implements HoldingDAO {
         HoldingDTO dto = new HoldingDTO();
 
         dto.setIso2709(rs.getBytes("iso2709"));
-
-        Record holdingMarcRecord = dto.getRecord();
-
-        if (holdingMarcRecord.getControlNumber() == null) {
-            dto.setId(rs.getInt("id"));
-        }
+        dto.setId(rs.getInt("id"));
 
         if (this.hasBiblioColumn(rs)) {
             BiblioRecordDTO biblioRecordDTO = new BiblioRecordDTO();

--- a/src/main/java/biblivre/circulation/lending/Handler.java
+++ b/src/main/java/biblivre/circulation/lending/Handler.java
@@ -136,6 +136,10 @@ public class Handler extends AbstractHandler {
             HoldingDTO holding =
                     (HoldingDTO) holdingBO.get(lending.getHoldingId(), RecordBO.MARC_INFO);
 
+            if (holding == null) {
+                continue;
+            }
+
             BiblioRecordDTO biblio =
                     (BiblioRecordDTO) biblioRecordBO.get(holding.getRecordId(), RecordBO.MARC_INFO);
 
@@ -226,10 +230,6 @@ public class Handler extends AbstractHandler {
             Integer holdingId = lending.getHoldingId();
 
             Integer userId = lending.getUserId();
-
-            HoldingDTO holding = (HoldingDTO) holdingBO.get(holdingId, RecordBO.MARC_INFO);
-
-            UserDTO user = userBO.get(userId);
 
             var lendingBag = createLendingBag(holdingId, userId);
 

--- a/src/main/java/biblivre/update/v6_0_0$8_0_1$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$8_0_1$alpha/Update.java
@@ -1,0 +1,120 @@
+package biblivre.update.v6_0_0$8_0_1$alpha;
+
+import biblivre.cataloging.holding.HoldingDTO;
+import biblivre.core.utils.Constants;
+import biblivre.record.RecordDataJDBCDAO;
+import biblivre.update.UpdateService;
+import biblivre.update.exception.UpdateException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.marc4j.marc.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Update implements UpdateService {
+    private static final Logger log = LoggerFactory.getLogger(Update.class);
+
+    private static final int BATCH_SIZE = 500;
+
+    @Override
+    public void doUpdateScopedBySchema(Connection connection) {
+        fixHoldingControlNumbers(connection);
+    }
+
+    private void fixHoldingControlNumbers(Connection connection) {
+        int fixed = 0;
+
+        try (PreparedStatement select =
+                        connection.prepareStatement(
+                                """
+                                SELECT id, iso2709
+                                FROM biblio_holdings
+                                ORDER BY id
+                                OFFSET ? LIMIT ?
+                                """);
+                PreparedStatement update =
+                        connection.prepareStatement(
+                                """
+                                UPDATE biblio_holdings
+                                SET iso2709 = ?, modified = now()
+                                WHERE id = ?
+                                """)) {
+            for (int offset = 0; ; offset += BATCH_SIZE) {
+                select.setInt(1, offset);
+                select.setInt(2, BATCH_SIZE);
+
+                int rows = 0;
+
+                try (ResultSet rs = select.executeQuery()) {
+                    while (rs.next()) {
+                        rows++;
+
+                        if (fixHoldingIfNeeded(rs, update, connection)) {
+                            fixed++;
+                        }
+                    }
+                }
+
+                if (rows < BATCH_SIZE) {
+                    break;
+                }
+            }
+        } catch (SQLException e) {
+            throw new UpdateException("Error fixing holding MARC 001 control numbers", e);
+        }
+
+        log.info("Fixed {} holding MARC 001 control numbers", fixed);
+    }
+
+    private boolean fixHoldingIfNeeded(
+            ResultSet rs, PreparedStatement update, Connection connection) throws SQLException {
+        int id = rs.getInt("id");
+        String iso2709 = rs.getString("iso2709");
+
+        HoldingDTO holding = new HoldingDTO();
+        holding.setIso2709(iso2709.getBytes(Constants.DEFAULT_CHARSET));
+
+        Record record = holding.getRecord();
+
+        if (record == null) {
+            log.warn("Skipping holding {} with unreadable MARC data", id);
+            return false;
+        }
+
+        if (!needsControlNumberFix(record, id)) {
+            return false;
+        }
+
+        holding.setId(id);
+
+        update.setString(1, holding.getUTF8Iso2709());
+        update.setInt(2, id);
+        update.executeUpdate();
+
+        try {
+            RecordDataJDBCDAO.updateRecordData(connection, holding);
+        } catch (SQLException e) {
+            throw new UpdateException("Error updating record_data for holding %d".formatted(id), e);
+        }
+
+        return true;
+    }
+
+    static boolean needsControlNumberFix(Record record, int id) {
+        var fields001 = record.getVariableFields("001");
+
+        if (fields001.size() != 1) {
+            return true;
+        }
+
+        return !expectedControlNumber(id).equals(record.getControlNumber());
+    }
+
+    static String expectedControlNumber(int id) {
+        return String.format("%07d", id);
+    }
+}

--- a/src/test/java/biblivre/cataloging/RecordDTOTest.java
+++ b/src/test/java/biblivre/cataloging/RecordDTOTest.java
@@ -1,0 +1,36 @@
+package biblivre.cataloging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import biblivre.marc.MarcUtils;
+import biblivre.marc.MaterialType;
+import biblivre.marc.RecordStatus;
+import org.junit.jupiter.api.Test;
+import org.marc4j.marc.Record;
+
+class RecordDTOTest {
+
+    @Test
+    void setIdReplacesMismatchedControlNumber() {
+        String humanReadableMarc =
+                """
+                000 00000cam a2200000 a 4500
+                001 0009999
+                245 10|aTest holding with wrong control number
+                """;
+
+        Record record =
+                MarcUtils.marcToRecord(humanReadableMarc, MaterialType.BOOK, RecordStatus.NEW);
+
+        RecordDTO dto = new RecordDTO();
+        dto.setRecord(record);
+
+        assertEquals(9999, dto.getId());
+
+        dto.setId(123);
+
+        assertEquals(123, dto.getId());
+        assertEquals("0000123", dto.getRecord().getControlNumber());
+        assertEquals(1, dto.getRecord().getVariableFields("001").size());
+    }
+}

--- a/src/test/java/biblivre/update/v6_0_0$8_0_1$alpha/UpdateTest.java
+++ b/src/test/java/biblivre/update/v6_0_0$8_0_1$alpha/UpdateTest.java
@@ -1,0 +1,51 @@
+package biblivre.update.v6_0_0$8_0_1$alpha;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import biblivre.marc.MarcUtils;
+import biblivre.marc.MaterialType;
+import biblivre.marc.RecordStatus;
+import org.junit.jupiter.api.Test;
+import org.marc4j.marc.MarcFactory;
+import org.marc4j.marc.Record;
+
+class UpdateTest {
+
+    @Test
+    void needsControlNumberFixWhen001DoesNotMatchId() {
+        Record record =
+                MarcUtils.marcToRecord(
+                        """
+                        000 00000cam a2200000 a 4500
+                        001 0009999
+                        245 10|aMismatched control number
+                        """,
+                        MaterialType.HOLDINGS,
+                        RecordStatus.NEW);
+
+        assertTrue(Update.needsControlNumberFix(record, 123));
+    }
+
+    @Test
+    void doesNotNeedControlNumberFixWhen001MatchesId() {
+        Record record =
+                MarcUtils.marcToRecord(
+                        """
+                        000 00000cam a2200000 a 4500
+                        001 0000123
+                        245 10|aMatching control number
+                        """,
+                        MaterialType.HOLDINGS,
+                        RecordStatus.NEW);
+
+        assertFalse(Update.needsControlNumberFix(record, 123));
+    }
+
+    @Test
+    void needsControlNumberFixWhen001IsMissing() {
+        Record record = MarcFactory.newInstance().newRecord();
+
+        assertTrue(Update.needsControlNumberFix(record, 123));
+    }
+}


### PR DESCRIPTION
Holdings whose MARC 001 diverged from biblio_holdings.id were keyed wrong in HoldingDAOImpl.map, so open lendings could not load holdings. Always use the database id, replace 001 on setId, and migrate existing mismatches via update v6_0_0$8_0_1$alpha.