### PR TITLE
fix: prevent AIOOB when Sunday is a business day

### DIFF
--- a/src/main/java/biblivre/core/utils/CalendarUtils.java
+++ b/src/main/java/biblivre/core/utils/CalendarUtils.java
@@ -52,10 +52,16 @@ public class CalendarUtils {
 
         int remainingDays = days;
 
+        // Indexed by DayOfWeek.getValue() (Monday=1 … Sunday=7). Index 0 unused.
         boolean[] isBusinessDay = new boolean[8];
 
         for (int businessDay : businessDays) {
-            isBusinessDay[businessDay - 1] = true;
+            isBusinessDay[toDayOfWeekValue(businessDay)] = true;
+        }
+
+        int businessDaysPerWeek = countBusinessDays(isBusinessDay);
+        if (businessDaysPerWeek == 0) {
+            return toDateInDefaultZone(expectedReturnDate.plusDays(days));
         }
 
         int daysToAdd = 0;
@@ -71,8 +77,6 @@ public class CalendarUtils {
         }
 
         if (remainingDays > 0) {
-            int businessDaysPerWeek = businessDays.size();
-
             int weeks = remainingDays / businessDaysPerWeek;
 
             remainingDays -= weeks * businessDaysPerWeek;
@@ -80,20 +84,44 @@ public class CalendarUtils {
             daysToAdd += weeks * 7;
         }
 
-        for (int i = DayOfWeek.MONDAY.getValue();
-                (remainingDays > 0 || !isBusinessDay[i]) && i <= DayOfWeek.SUNDAY.getValue();
-                i++) {
-
+        int i = DayOfWeek.MONDAY.getValue();
+        while (remainingDays > 0 || !isBusinessDay[i]) {
             daysToAdd++;
 
             if (isBusinessDay[i]) {
                 remainingDays--;
+            }
+
+            i++;
+            if (i > DayOfWeek.SUNDAY.getValue()) {
+                i = DayOfWeek.MONDAY.getValue();
             }
         }
 
         assert remainingDays == 0;
 
         return toDateInDefaultZone(expectedReturnDate.plusDays(daysToAdd));
+    }
+
+    /**
+     * Converts {@link Calendar#DAY_OF_WEEK} values (Sunday=1 … Saturday=7), as stored in {@code
+     * general.business_days}, to {@link DayOfWeek#getValue()} (Monday=1 … Sunday=7).
+     */
+    static int toDayOfWeekValue(int calendarDayOfWeek) {
+        if (calendarDayOfWeek == Calendar.SUNDAY) {
+            return DayOfWeek.SUNDAY.getValue();
+        }
+        return calendarDayOfWeek - 1;
+    }
+
+    private static int countBusinessDays(boolean[] isBusinessDay) {
+        int count = 0;
+        for (int d = DayOfWeek.MONDAY.getValue(); d <= DayOfWeek.SUNDAY.getValue(); d++) {
+            if (isBusinessDay[d]) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public static Date toDateInDefaultZone(java.time.LocalDate expectedReturnDate) {

--- a/src/test/java/biblivre/core/utils/CalendarUtilsTest.java
+++ b/src/test/java/biblivre/core/utils/CalendarUtilsTest.java
@@ -30,6 +30,34 @@ public class CalendarUtilsTest {
                                 toDate(LocalDate.of(2024, 10, 21)), 50, List.of(3, 4, 5, 6))));
     }
 
+    /**
+     * Business-day config uses Calendar/Globalize numbering (1=Sunday … 7=Saturday). Including
+     * Sunday used to throw ArrayIndexOutOfBoundsException because Sunday was stored at index 0
+     * while DayOfWeek.SUNDAY is read at index 7.
+     */
+    @Test
+    void calculateExpectedReturnDate_whenSundayIsBusinessDay_doesNotThrow() {
+        // Friday 2026-08-07 — same shape as the production stacktrace
+        Date lendingDate = toDate(LocalDate.of(2026, 8, 7));
+        List<Integer> sundayToFriday = List.of(1, 2, 3, 4, 5, 6);
+
+        assertEquals(
+                LocalDate.of(2026, 8, 14),
+                toLocalDateInDefaultZone(
+                        CalendarUtils.calculateExpectedReturnDate(lendingDate, 6, sundayToFriday)));
+    }
+
+    @Test
+    void calculateExpectedReturnDate_whenAllWeekdaysAreBusinessDays_doesNotThrow() {
+        Date lendingDate = toDate(LocalDate.of(2026, 8, 7));
+        List<Integer> allDays = List.of(1, 2, 3, 4, 5, 6, 7);
+
+        assertEquals(
+                LocalDate.of(2026, 8, 15),
+                toLocalDateInDefaultZone(
+                        CalendarUtils.calculateExpectedReturnDate(lendingDate, 8, allDays)));
+    }
+
     LocalDate toLocalDateInDefaultZone(Date date) {
         return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
     }


### PR DESCRIPTION
## Summary
- `general.business_days` uses Calendar numbering (`1=Sunday`), but `calculateExpectedReturnDate` indexed Sunday at `0` while loops read `DayOfWeek.SUNDAY` at `7`.
- That left Sunday uncounted, inflated the week size, and let the final loop walk past Sunday into index `8` — the `ArrayIndexOutOfBoundsException` seen on lend.
- Map Calendar day values to `DayOfWeek`, count real business days per week, and wrap the remainder loop safely; add regression tests for Sunday-inclusive configs.

## Test plan
- [x] `mvn test -Dtest=CalendarUtilsTest -P developer`
- [ ] Lend an item with `general.business_days` including Sunday (e.g. `1,2,3,4,5,6`) and confirm expected return date is set without error
- [ ] Lend with default Mon–Fri (`2,3,4,5,6`) and confirm return dates unchanged


Made with [Cursor](https://cursor.com)