### PR TITLE
ci: speed up GitHub Actions with shared frontend and Docker caches

### DIFF
--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -21,6 +21,8 @@ jobs:
             cleydyr/biblivre
           tags: |
             type=sha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
@@ -33,6 +35,27 @@ jobs:
           distribution: "zulu"
           java-version: "25"
           cache: 'maven'
+      - name: Get Node and Yarn versions
+        id: frontend-versions
+        run: |
+          echo "node=$(grep -oP '(?<=<nodeVersion>)[^<]+' pom.xml)" >> $GITHUB_OUTPUT
+          echo "yarn=$(grep -oP '(?<=<yarnVersion>)[^<]+' pom.xml)" >> $GITHUB_OUTPUT
+      - name: Cache frontend-maven-plugin Node/Yarn downloads
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository/com/github/eirslett
+          key: frontend-maven-plugin-${{ runner.os }}-${{ steps.frontend-versions.outputs.node }}-${{ steps.frontend-versions.outputs.yarn }}
+          restore-keys: |
+            frontend-maven-plugin-${{ runner.os }}-
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/yarn
+            src/main/spa-frontend/node_modules
+          key: yarn-${{ runner.os }}-${{ hashFiles('src/main/spa-frontend/yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
       - name: Cache Dart Sass downloads
         uses: actions/cache@v6
         with:
@@ -57,3 +80,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -22,7 +22,7 @@ jobs:
           tags: |
             type=sha
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,20 +37,24 @@ jobs:
           server-id: ossindex
           server-username: ${{ secrets.OSSINDEX_USERNAME }}
           server-password: ${{ secrets.OSSINDEX_TOKEN }}
-      - name: Get Yarn version
-        id: yarn-version
-        run: echo "version=$(grep -oP '(?<=<yarnVersion>)[^<]+' pom.xml)" >> $GITHUB_OUTPUT
+      - name: Get Node and Yarn versions
+        id: frontend-versions
+        run: |
+          echo "node=$(grep -oP '(?<=<nodeVersion>)[^<]+' pom.xml)" >> $GITHUB_OUTPUT
+          echo "yarn=$(grep -oP '(?<=<yarnVersion>)[^<]+' pom.xml)" >> $GITHUB_OUTPUT
       - name: Cache frontend-maven-plugin Node/Yarn downloads
         uses: actions/cache@v6
         with:
           path: ~/.m2/repository/com/github/eirslett
-          key: frontend-maven-plugin-${{ runner.os }}-${{ steps.yarn-version.outputs.version }}
+          key: frontend-maven-plugin-${{ runner.os }}-${{ steps.frontend-versions.outputs.node }}-${{ steps.frontend-versions.outputs.yarn }}
           restore-keys: |
             frontend-maven-plugin-${{ runner.os }}-
       - name: Cache Yarn dependencies
         uses: actions/cache@v6
         with:
-          path: src/main/spa-frontend/node_modules
+          path: |
+            ~/.cache/yarn
+            src/main/spa-frontend/node_modules
           key: yarn-${{ runner.os }}-${{ hashFiles('src/main/spa-frontend/yarn.lock') }}
           restore-keys: |
             yarn-${{ runner.os }}-


### PR DESCRIPTION
## Summary
- Align `push_docker.yml` with the CI frontend caches (frontend-maven-plugin downloads and Yarn/`node_modules`) so Docker image builds reuse the same work as `test.yml`.
- Enable Docker Buildx with GitHub Actions layer cache (`cache-from`/`cache-to: type=gha`) for faster image builds.
- Tighten CI cache keys to include both Node and Yarn versions from `pom.xml`, and also cache `~/.cache/yarn`.

## Test plan
- [ ] Confirm the CI workflow on this PR restores Maven/Yarn/Sass caches (or populates them on first run)
- [ ] After merge to `master`, confirm `push_docker` restores the new frontend caches and reports Buildx GHA cache import/export
- [ ] Spot-check that Node/Yarn version bumps in `pom.xml` invalidate the frontend-maven-plugin cache key


Made with [Cursor](https://cursor.com)