### PR TITLE
fix: align all-users report counts with listed users

### DIFF
--- a/src/main/java/biblivre/administration/reports/AllUsersReport.java
+++ b/src/main/java/biblivre/administration/reports/AllUsersReport.java
@@ -21,6 +21,12 @@ package biblivre.administration.reports;
 
 import biblivre.administration.reports.dto.AllUsersReportDto;
 import biblivre.administration.reports.dto.BaseReportDto;
+import biblivre.circulation.user.UserStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import org.openpdf.text.Document;
 import org.openpdf.text.Element;
 import org.openpdf.text.Paragraph;
@@ -28,11 +34,6 @@ import org.openpdf.text.Phrase;
 import org.openpdf.text.Rectangle;
 import org.openpdf.text.pdf.PdfPCell;
 import org.openpdf.text.pdf.PdfPTable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -90,7 +91,11 @@ public class AllUsersReport extends BaseBiblivreReport {
             int count = entry.getValue();
 
             total += count;
-            cell = new PdfPCell(new Paragraph(this.getHeaderChunk(entry.getKey().toUpperCase())));
+            cell =
+                    new PdfPCell(
+                            new Paragraph(
+                                    this.getHeaderChunk(
+                                            resolveTypeLabel(entry.getKey()).toUpperCase())));
             cell.setBackgroundColor(HEADER_BG_COLOR);
             cell.setHorizontalAlignment(Element.ALIGN_CENTER);
             cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
@@ -126,13 +131,29 @@ public class AllUsersReport extends BaseBiblivreReport {
             for (Entry<String, List<String>> entry : data.entrySet()) {
                 table = new PdfPTable(4);
                 table.setWidthPercentage(100f);
-                String description = entry.getKey();
+                String description = resolveTypeLabel(entry.getKey());
                 cell = new PdfPCell(new Paragraph(this.getHeaderChunk(description.toUpperCase())));
                 cell.setColspan(4);
                 cell.setBorder(Rectangle.NO_BORDER);
                 cell.setHorizontalAlignment(Element.ALIGN_LEFT);
                 cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
                 table.addCell(cell);
+
+                List<String> users = entry.getValue();
+                if (users == null || users.isEmpty()) {
+                    cell =
+                            new PdfPCell(
+                                    new Paragraph(
+                                            this.getNormalChunk(
+                                                    this.getText(
+                                                            "administration.reports.field.no_users_for_criteria"))));
+                    cell.setColspan(4);
+                    cell.setHorizontalAlignment(Element.ALIGN_LEFT);
+                    cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
+                    table.addCell(cell);
+                    tabelas.add(table);
+                    continue;
+                }
 
                 cell =
                         new PdfPCell(
@@ -182,7 +203,7 @@ public class AllUsersReport extends BaseBiblivreReport {
                 cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
                 table.addCell(cell);
 
-                for (String line : entry.getValue()) {
+                for (String line : users) {
                     String[] dados = line.split("\t");
                     // Nome
                     cell = new PdfPCell(new Paragraph(this.getNormalChunk(dados[0])));
@@ -215,6 +236,13 @@ public class AllUsersReport extends BaseBiblivreReport {
             logger.error(e.getMessage(), e);
             return Collections.emptyList();
         }
+    }
+
+    private String resolveTypeLabel(String typeKey) {
+        if (UserStatus.INACTIVE.toString().equals(typeKey)) {
+            return this.getText("administration.reports.field.inactive_users");
+        }
+        return typeKey;
     }
 
     @Override

--- a/src/main/java/biblivre/administration/reports/ReportsDAOImpl.java
+++ b/src/main/java/biblivre/administration/reports/ReportsDAOImpl.java
@@ -32,6 +32,7 @@ import biblivre.marc.MarcUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -278,13 +279,13 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
         try (Connection con = datasource.getConnection()) {
             String sqlTotal =
                     """
-                            SELECT to_char(created, 'DD/MM/YYYY'), user_name, count(created_by)
-                            FROM holding_creation_counter
-                            WHERE created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                            GROUP BY user_name, to_char(created, 'DD/MM/YYYY')
-                            ORDER BY to_char(created, 'DD/MM/YYYY'), user_name
-                            """;
+                    SELECT to_char(created, 'DD/MM/YYYY'), user_name, count(created_by)
+                    FROM holding_creation_counter
+                    WHERE created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                    GROUP BY user_name, to_char(created, 'DD/MM/YYYY')
+                    ORDER BY to_char(created, 'DD/MM/YYYY'), user_name
+                    """;
             PreparedStatement st = con.prepareStatement(sqlTotal);
             st.setString(1, initialDate);
             st.setString(2, finalDate);
@@ -301,10 +302,10 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlBiblioMain =
                     """
-                            SELECT COUNT(id) FROM biblio_records
-                            WHERE database = 'main' AND created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                            """;
+                    SELECT COUNT(id) FROM biblio_records
+                    WHERE database = 'main' AND created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                    """;
 
             st = con.prepareStatement(sqlBiblioMain);
             st.setString(1, initialDate);
@@ -316,10 +317,10 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlBiblioWork =
                     """
-                            SELECT COUNT(id) FROM biblio_records
-                            WHERE database = 'work' AND created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                            """;
+                    SELECT COUNT(id) FROM biblio_records
+                    WHERE database = 'work' AND created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                    """;
 
             st = con.prepareStatement(sqlBiblioWork);
             st.setString(1, initialDate);
@@ -331,10 +332,10 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlHoldingMain =
                     """
-                            SELECT COUNT(id) FROM biblio_holdings
-                            WHERE database = 'main' AND created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                            """;
+                    SELECT COUNT(id) FROM biblio_holdings
+                    WHERE database = 'main' AND created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                    """;
             st = con.prepareStatement(sqlHoldingMain);
             st.setString(1, initialDate);
             st.setString(2, finalDate);
@@ -345,10 +346,10 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlHoldingWork =
                     """
-                            SELECT COUNT(id) FROM biblio_holdings
-                            WHERE database = 'work' AND created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                            """;
+                    SELECT COUNT(id) FROM biblio_holdings
+                    WHERE database = 'work' AND created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                    """;
 
             st = con.prepareStatement(sqlHoldingWork);
             st.setString(1, initialDate);
@@ -379,12 +380,12 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
         try (Connection con = datasource.getConnection()) {
             String sqlLent =
                     """
-                            SELECT count(*)
-                            FROM lendings
-                            WHERE created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                                AND return_date IS NULL
-                            """;
+                    SELECT count(*)
+                    FROM lendings
+                    WHERE created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                        AND return_date IS NULL
+                    """;
             st = con.prepareStatement(sqlLent);
             st.setString(1, initialDate);
             st.setString(2, finalDate);
@@ -396,12 +397,12 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlHistory =
                     """
-                            SELECT count(*)
-                            FROM lendings
-                            WHERE created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                                AND return_date IS NOT NULL
-                            """;
+                    SELECT count(*)
+                    FROM lendings
+                    WHERE created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                        AND return_date IS NOT NULL
+                    """;
 
             st = con.prepareStatement(sqlHistory);
             st.setString(1, initialDate);
@@ -414,13 +415,13 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlLate =
                     """
-                            SELECT count(*)
-                            FROM lendings
-                            WHERE created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                                AND expected_return_date < to_date(?, 'DD-MM-YYYY')
-                                AND return_date IS NULL
-                            """;
+                    SELECT count(*)
+                    FROM lendings
+                    WHERE created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                        AND expected_return_date < to_date(?, 'DD-MM-YYYY')
+                        AND return_date IS NULL
+                    """;
 
             st = con.prepareStatement(sqlLate);
             st.setString(1, initialDate);
@@ -437,16 +438,16 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
             String sqlTop20 =
                     """
-                            SELECT b.iso2709, count(b.id) AS rec_count
-                            FROM lendings l, biblio_records b, biblio_holdings h
-                            WHERE l.holding_id = h.id
-                                AND l.created >= to_date(?, 'DD-MM-YYYY')
-                                AND l.created <= to_date(?, 'DD-MM-YYYY')
-                                AND h.record_id = b.id
-                            GROUP BY b.id
-                            ORDER BY rec_count DESC
-                            LIMIT 20;
-                            """;
+                    SELECT b.iso2709, count(b.id) AS rec_count
+                    FROM lendings l, biblio_records b, biblio_holdings h
+                    WHERE l.holding_id = h.id
+                        AND l.created >= to_date(?, 'DD-MM-YYYY')
+                        AND l.created <= to_date(?, 'DD-MM-YYYY')
+                        AND h.record_id = b.id
+                    GROUP BY b.id
+                    ORDER BY rec_count DESC
+                    LIMIT 20;
+                    """;
 
             st = con.prepareStatement(sqlTop20);
             st.setString(1, initialDate);
@@ -517,13 +518,13 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
         try (Connection con = datasource.getConnection()) {
             final String sql =
                     """
-                            SELECT count(created), to_char(created, 'YYYY-MM-DD')
-                            FROM biblio_searches
-                            WHERE created >= to_date(?, 'DD-MM-YYYY')
-                                AND created <= to_date(?, 'DD-MM-YYYY')
-                            GROUP BY to_char(created, 'YYYY-MM-DD')
-                            ORDER BY to_char(created, 'YYYY-MM-DD') ASC
-                            """;
+                    SELECT count(created), to_char(created, 'YYYY-MM-DD')
+                    FROM biblio_searches
+                    WHERE created >= to_date(?, 'DD-MM-YYYY')
+                        AND created <= to_date(?, 'DD-MM-YYYY')
+                    GROUP BY to_char(created, 'YYYY-MM-DD')
+                    ORDER BY to_char(created, 'YYYY-MM-DD') ASC
+                    """;
 
             final PreparedStatement st = con.prepareStatement(sql);
             st.setString(1, initialDate);
@@ -550,13 +551,13 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
     @Override
     public AllUsersReportDto getAllUsersReportData() {
         AllUsersReportDto dto = new AllUsersReportDto();
-        dto.setTypesMap(new HashMap<>());
-        dto.setData(new HashMap<>());
+        dto.setTypesMap(new LinkedHashMap<>());
+        dto.setData(new LinkedHashMap<>());
 
         try (Connection con = datasource.getConnection()) {
 
             String firstSql =
-                            """
+                    """
                     SELECT count(u.type) as total, t.description, t.id
                     FROM users u, users_types t
                     WHERE u.type = t.id
@@ -574,35 +575,71 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
                 dto.getTypesMap().put(description, count);
 
                 String secondSql =
-                                """
+                        """
                         SELECT name, id, created, modified
                         FROM users
                         WHERE type = '%s'
+                            AND status <> '%s'
                         ORDER BY name
                         """
-                                .formatted(rs.getInt("id"));
+                                .formatted(rs.getInt("id"), UserStatus.INACTIVE);
 
                 ResultSet rs2 = con.createStatement().executeQuery(secondSql);
                 List<String> dataList = new ArrayList<>();
                 while (rs2.next()) {
-                    var str =
-                                    """
-                            %s\t%d\t%s\t%s
-                            """
-                                    .formatted(
-                                            rs2.getString("name"),
-                                            rs2.getInt("id"),
-                                            dd_MM_yyyy.format(rs2.getDate("created")),
-                                            dd_MM_yyyy.format(rs2.getDate("modified")));
-                    dataList.add(str);
+                    dataList.add(formatUserReportLine(rs2));
                 }
                 dto.getData().put(description, dataList);
             }
+
+            String inactiveStatus = UserStatus.INACTIVE.toString();
+
+            String sqlCountInactive =
+                    """
+                    SELECT count(id) as total
+                    FROM users
+                    WHERE status = '%s'
+                    """
+                            .formatted(UserStatus.INACTIVE);
+
+            ResultSet rsCountInactive = con.createStatement().executeQuery(sqlCountInactive);
+            int inactiveCount = 0;
+            if (rsCountInactive.next()) {
+                inactiveCount = rsCountInactive.getInt("total");
+            }
+            dto.getTypesMap().put(inactiveStatus, inactiveCount);
+
+            String sqlInactive =
+                    """
+                    SELECT name, id, created, modified
+                    FROM users
+                    WHERE status = '%s'
+                    ORDER BY name
+                    """
+                            .formatted(UserStatus.INACTIVE);
+
+            ResultSet rsInactive = con.createStatement().executeQuery(sqlInactive);
+            List<String> inactiveDataList = new ArrayList<>();
+            while (rsInactive.next()) {
+                inactiveDataList.add(formatUserReportLine(rsInactive));
+            }
+            dto.getData().put(inactiveStatus, inactiveDataList);
 
         } catch (Exception e) {
             throw new DAOException(e);
         }
         return dto;
+    }
+
+    private static String formatUserReportLine(ResultSet rs) throws SQLException {
+        return """
+                %s\t%d\t%s\t%s
+                """
+                .formatted(
+                        rs.getString("name"),
+                        rs.getInt("id"),
+                        dd_MM_yyyy.format(rs.getDate("created")),
+                        dd_MM_yyyy.format(rs.getDate("modified")));
     }
 
     @Override
@@ -653,7 +690,7 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
         try (Connection con = datasource.getConnection()) {
             String sql =
-                            """
+                    """
                     SELECT DISTINCT B.id, B.iso2709 FROM biblio_records B
                     INNER JOIN biblio_idx_fields I ON I.record_id = B.id
                     WHERE B.database = ?
@@ -712,7 +749,7 @@ public class ReportsDAOImpl extends AbstractDAO implements ReportsDAO {
 
         try (Connection con = datasource.getConnection()) {
             String sql =
-                            """
+                    """
                     SELECT iso2709 FROM biblio_records
                     WHERE id IN (%s)
                     ORDER BY id ASC;

--- a/src/main/java/biblivre/update/v6_0_0$8_0_2$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$8_0_2$alpha/Update.java
@@ -1,0 +1,47 @@
+package biblivre.update.v6_0_0$8_0_2$alpha;
+
+import biblivre.core.translations.TranslationBO;
+import biblivre.update.UpdateService;
+import biblivre.update.exception.UpdateException;
+import java.sql.Connection;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Update implements UpdateService {
+
+    private TranslationBO translationBO;
+
+    @Override
+    public void doUpdate(Connection connection) throws UpdateException {
+        addTranslations();
+    }
+
+    private void addTranslations() {
+        for (Map.Entry<String, Map<String, String>> entry : TRANSLATIONS.entrySet()) {
+            for (Map.Entry<String, String> translation : entry.getValue().entrySet()) {
+                translationBO.addSingleTranslation(
+                        translation.getKey(), entry.getKey(), translation.getValue());
+            }
+        }
+    }
+
+    @Autowired
+    public void setTranslationsBO(TranslationBO translationBO) {
+        this.translationBO = translationBO;
+    }
+
+    private static final Map<String, Map<String, String>> TRANSLATIONS =
+            Map.of(
+                    "administration.reports.field.inactive_users",
+                    Map.of("pt-BR", "Inativos", "es", "Inactivos", "en-US", "Inactive users"),
+                    "administration.reports.field.no_users_for_criteria",
+                    Map.of(
+                            "pt-BR",
+                            "Não há usuários com esse critério",
+                            "es",
+                            "No hay usuarios con este criterio",
+                            "en-US",
+                            "There are no users matching this criterion"));
+}

--- a/src/main/resources/META-INF/data/translations.ndjson
+++ b/src/main/resources/META-INF/data/translations.ndjson
@@ -6351,3 +6351,9 @@
 {"language":"en-US","key":"cataloging.import.error.file_upload_error","text":"Couldn't upload file. Please contact the administrator to analyze thisproblem.","user_created":false}
 {"language":"pt-BR","key":"cataloging.import.error.file_upload_error","text":"Não foi possível fazer upload do arquivo. Por favor, contacte o administrador do sistema para anlizar este problema.","user_created":false}
 {"language":"es","key":"cataloging.import.error.file_upload_error","text":"No ha sido posible subir el archivo. Por favor, contacta el administrador del sistema para analizar este problema.","user_created":false}
+{"language":"pt-BR","key":"administration.reports.field.inactive_users","text":"Inativos","user_created":false}
+{"language":"es","key":"administration.reports.field.inactive_users","text":"Inactivos","user_created":false}
+{"language":"en-US","key":"administration.reports.field.inactive_users","text":"Inactive users","user_created":false}
+{"language":"pt-BR","key":"administration.reports.field.no_users_for_criteria","text":"Não há usuários com esse critério","user_created":false}
+{"language":"es","key":"administration.reports.field.no_users_for_criteria","text":"No hay usuarios con este criterio","user_created":false}
+{"language":"en-US","key":"administration.reports.field.no_users_for_criteria","text":"There are no users matching this criterion","user_created":false}


### PR DESCRIPTION
## Summary
- Fix the all-users report inconsistency where inactive users were excluded from type totals but still appeared in the per-type lists.
- Add a dedicated inactive-users section (always shown), with i18n labels resolved in the report layer and an empty-state message when there are no matching users.
- Ship translations via translations.ndjson and update v6_0_0$8_0_2$alpha.

## Test plan
- [x] Generate Relatorio Geral de Usuarios and confirm each type count matches the number of listed rows.
- [x] Confirm inactive users appear only under the inactive section.
- [x] With zero inactive users, confirm the inactive section still appears with the no-users-for-criteria message.
- [ ] Switch locale (pt-BR / en-US / es) and confirm inactive section title is translated.
- [ ] After upgrade, confirm the new translation keys are present.

Made with [Cursor](https://cursor.com)