### PR TITLE
fix(ci): wire OSS Index auth correctly for setup-java

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       BABEL_ENV: production
       BUILD_PATH: ../resources/META-INF/resources/static/
       PUBLIC_URL: /static/
+      # Consumed by ~/.m2/settings.xml written by setup-java (${env.OSSINDEX_*}).
+      OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+      OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
 
     steps:
       - uses: actions/checkout@v7
@@ -39,9 +42,10 @@ jobs:
           distribution: "zulu"
           java-version: "25"
           cache: "maven"
+          # setup-java expects env *names* here (not secret values).
           server-id: ossindex
-          server-username: ${{ secrets.OSSINDEX_USERNAME }}
-          server-password: ${{ secrets.OSSINDEX_TOKEN }}
+          server-username: OSSINDEX_USERNAME
+          server-password: OSSINDEX_TOKEN
 
       - name: Get Node and Yarn versions
         id: frontend-versions


### PR DESCRIPTION
## Summary
- `actions/setup-java` expects `server-username` / `server-password` to be **environment variable names**, not secret values; it writes `${env.NAME}` into `~/.m2/settings.xml`.
- Pass `OSSINDEX_USERNAME` / `OSSINDEX_TOKEN` as those names and expose the corresponding Actions secrets on the build job so Maven can authenticate the `ossindex:audit` call (avoids HTTP 401).

## Test plan
- [x] Ensure repo secrets `OSSINDEX_USERNAME` and `OSSINDEX_TOKEN` match the local `~/.m2/settings.xml` `<server><id>ossindex</id>` entry
- [x] Confirm CI no longer logs `Failed to fetch component-reports` / `401 Unauthorized` from `ossindex-maven-plugin`
- [x] Confirm local `mvn ossindex:audit` still succeeds with existing settings.xml


Made with [Cursor](https://cursor.com)