### PR TITLE
ci: cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ on:
   pull_request:
     branches: [master]
 
+# Cancel superseded PR runs (e.g. Renovate force-pushes). Keep master/tag
+# runs so an in-flight Docker publish is not aborted by a later push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Default least privilege for GITHUB_TOKEN. Write scopes are granted per job
 # (Sonar githubactions:S8233 / CodeQL missing-workflow-permissions).
 permissions:


### PR DESCRIPTION
## Summary
- Add workflow `concurrency` so superseded PR runs (e.g. Renovate force-pushes) are cancelled in progress
- Keep `cancel-in-progress` off for master/tag pushes so an in-flight Docker publish is not aborted

## Test plan
- [ ] Open/update a PR twice quickly and confirm the older CI run is cancelled
- [ ] Push to master (or watch next merge) and confirm the Docker job is not cancelled by a subsequent push mid-run


Made with [Cursor](https://cursor.com)