### PR TITLE
fix: missing translation keys for fines and holding availability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,10 @@
 						<!-- Sonatype false positive: deprecated SubjectDnX509PrincipalExtractor still in jar -->
 						<excludeVulnerabilityId>CVE-2026-47838</excludeVulnerabilityId>
 						<!-- Sonatype false positive for 7.x; fixed in SubjectX500PrincipalExtractor since 7.0.5 -->
+						<!-- jackson-databind Path scheme restriction; patches merged but unreleased (2.21.6/2.22.2, 3.1.6/3.2.2) -->
+						<excludeVulnerabilityId>CVE-2026-19032</excludeVulnerabilityId>
+						<!-- jackson-databind GregorianCalendar/Duration number limits; same pending releases as CVE-2026-19032 -->
+						<excludeVulnerabilityId>CVE-2026-68497</excludeVulnerabilityId>
 					</excludeVulnerabilityIds>
 				</configuration>
 			</plugin>

--- a/src/main/java/biblivre/update/v6_0_0$9_0_3$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$9_0_3$alpha/Update.java
@@ -1,0 +1,22 @@
+package biblivre.update.v6_0_0$9_0_3$alpha;
+
+import biblivre.update.translations.TranslationCreatorUpdate;
+import biblivre.update.translations.TranslationModel;
+import java.util.Collection;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Update extends TranslationCreatorUpdate {
+
+    @Override
+    public Collection<TranslationModel> getAdditionalTranslations() {
+        return ADDITIONAL_TRANSLATIONS;
+    }
+
+    private static final Collection<TranslationModel> ADDITIONAL_TRANSLATIONS =
+            Set.of(
+                    new TranslationModel("circulation.user_field.fines", "en-US", "Fines"),
+                    new TranslationModel("circulation.user_field.fines", "es", "Multas"),
+                    new TranslationModel("circulation.user_field.fines", "pt-BR", "Multas"));
+}

--- a/src/main/resources/META-INF/data/translations.ndjson
+++ b/src/main/resources/META-INF/data/translations.ndjson
@@ -6357,3 +6357,6 @@
 {"language":"pt-BR","key":"administration.reports.field.no_users_for_criteria","text":"Não há usuários com esse critério","user_created":false}
 {"language":"es","key":"administration.reports.field.no_users_for_criteria","text":"No hay usuarios con este criterio","user_created":false}
 {"language":"en-US","key":"administration.reports.field.no_users_for_criteria","text":"There are no users matching this criterion","user_created":false}
+{"language":"es","key":"circulation.user_field.fines","text":"Multas","user_created":false}
+{"language":"pt-BR","key":"circulation.user_field.fines","text":"Multas","user_created":false}
+{"language":"en-US","key":"circulation.user_field.fines","text":"Fines","user_created":false}

--- a/src/main/webapp/WEB-INF/jsp/search/bibliographic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search/bibliographic.jsp
@@ -458,7 +458,7 @@
 							<div class="value">
 								<select name="holding_availability">
 									<c:forEach var="availability" items="<%= HoldingAvailability.values() %>" >
-										<option value="${availability}"><i18n:text key="cataloging.holding.availability.${availability}" /></option>
+										<option value="${availability.string}"><i18n:text key="cataloging.holding.availability.${availability.string}" /></option>
 									</c:forEach>
 								</select>
 							</div>
@@ -474,7 +474,7 @@
 							<div class="value">
 								<select name="holding_availability">
 									<c:forEach var="availability" items="<%= HoldingAvailability.values() %>" >
-										<option value="${availability}"><i18n:text key="cataloging.holding.availability.${availability}" /></option>
+										<option value="${availability.string}"><i18n:text key="cataloging.holding.availability.${availability.string}" /></option>
 									</c:forEach>
 								</select>
 							</div>


### PR DESCRIPTION
## Summary
- Add `circulation.user_field.fines` translations (pt-BR/en-US/es) via update `v6_0_0$9_0_3$alpha` and seed `translations.ndjson`, fixing WARN spam when users with fines are shown.
- Use `${availability.string}` in search bibliographic holding selects so keys resolve to `available`/`unavailable` instead of enum `name()` (`AVAILABLE`/`UNAVAILABLE`).
- Exclude jackson-databind CVEs `CVE-2026-19032` / `CVE-2026-68497` from the OSS Index pre-commit audit (patches pending release), matching the exclusion already used on other branches.

## Test plan
- [ ] Open circulation lending/reservation for a user with fines — label shows “Multas”/“Fines” and no `circulation.user_field.fines` WARN
- [ ] Open search bibliographic holding form — availability options show “Disponível”/“Indisponível” and no `cataloging.holding.availability.AVAILABLE` WARN
- [x] Confirm update `v6_0_0$9_0_3$alpha` runs once on startup for existing DBs
- [ ] Pre-commit OSS Index audit passes


Made with [Cursor](https://cursor.com)