### PR TITLE
chore(spa): enable no-nested-ternary in ESLint

### DIFF
--- a/src/main/spa-frontend/eslint.config.js
+++ b/src/main/spa-frontend/eslint.config.js
@@ -161,6 +161,8 @@ export default tseslint.config([
 
       // Prefer <Fragment> over shorthand <> (autofixable)
       'biblivre/prefer-fragment-element': 'error',
+      // Nested ternaries hurt readability; prefer if/else or early returns
+      'no-nested-ternary': 'error',
     },
   },
 


### PR DESCRIPTION
## Summary
- Enable `no-nested-ternary` in the SPA ESLint config so nested conditionals are rejected in favor of clearer control flow

## Test plan
- [ ] `cd src/main/spa-frontend && yarn lint` passes on master after this change (or only flags intentional nested ternaries)
- [ ] Confirm rule lives next to the other readability/ternary rules in `eslint.config.js`


Made with [Cursor](https://cursor.com)