### PR TITLE
chore(cursor): agent compile and SPA build sanity rules

### DIFF
--- a/.cursor/rules/compile-sanity-check.mdc
+++ b/.cursor/rules/compile-sanity-check.mdc
@@ -1,0 +1,28 @@
+---
+description: Run a basic compile sanity check before treating Java/backend code changes as done
+globs: "**/*.{java,xml,yml,yaml}"
+alwaysApply: false
+---
+
+# Compile sanity check (backend)
+
+After changing Java sources, Maven config, or Spring config that can affect compilation/classpath, verify the project still compiles **before** presenting the change as done (and before commit/push when those were requested).
+
+```bash
+set -o pipefail
+mvn -DskipTests compile -Pdeveloper
+```
+
+## Requirements
+
+- Treat a non-zero Maven exit code as failure; fix it before finishing.
+- If you pipe Maven output (`| tail`, `| rg`, etc.), keep `set -o pipefail` so the pipeline exit code reflects Maven, not the last filter.
+- Prefer a **clean** compile when the change adds/changes imports, Spring Boot/Framework APIs, or dependencies — incremental compile can hide missing packages:
+
+```bash
+set -o pipefail
+mvn -DskipTests clean compile -Pdeveloper
+```
+
+- Do not claim “compiles” from an incremental run alone in those cases.
+- Frontend-only SPA edits: follow `spa-frontend-yarn-lint.mdc` (`yarn lint && yarn build`) instead of this Maven check.

--- a/.cursor/rules/spa-frontend-yarn-lint.mdc
+++ b/.cursor/rules/spa-frontend-yarn-lint.mdc
@@ -1,0 +1,20 @@
+---
+description: Always run yarn lint and yarn build after spa-frontend contributions
+globs: src/main/spa-frontend/**/*.{ts,tsx,js,jsx,mjs,cjs}
+alwaysApply: false
+---
+
+# spa-frontend: lint and build sanity check
+
+After editing or adding files under `src/main/spa-frontend`, run both checks before considering the work done:
+
+```bash
+cd src/main/spa-frontend && yarn lint && yarn build
+```
+
+- Fix every reported ESLint error in files you changed.
+- Prefer fixing issues manually; use `yarn lint:fix` only for safe auto-fixes.
+- Treat a failed `yarn build` (TypeScript, Vite, bundling) as a blocker — fix it before finishing.
+- Do not leave lint or build failures in your final suggestions.
+- If either step fails, resolve the issues and re-run until both pass.
+- Use `set -o pipefail` if you pipe the command output through filters.


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/compile-sanity-check.mdc` so agents run a Maven compile sanity check after backend/config changes (including clean compile when imports/APIs/deps change, and `pipefail` when piping output).
- Add/extend `.cursor/rules/spa-frontend-yarn-lint.mdc` to require `yarn lint && yarn build` after spa-frontend edits.

## Test plan
- [ ] Confirm both rule files render correctly in Cursor rule picker / apply on matching globs
- [ ] Open a Java file and verify the compile sanity rule is suggested/applied
- [ ] Open a spa-frontend TSX file and verify lint+build rule is suggested/applied


Made with [Cursor](https://cursor.com)