### PR TITLE
fix: restore RestClient.Builder wiring on Boot 4.1 startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,12 @@ jobs:
             mvn -B -ntp clean test package -Pgithub-ci
           fi
 
+      # Real process boot (developer Spring profile + docker-compose.dev DB), not
+      # @SpringBootTest/test profile — catches missing runtime beans such as
+      # RestClient.Builder under Boot 4.1+.
+      - name: Smoke start server (developer mode)
+        run: ./scripts/smoke-dev.sh
+
       - name: Upload packaged app
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GREEN := \033[0;32m
 YELLOW := \033[1;33m
 NC := \033[0m # No Color
 
-.PHONY: help dev dev-spa debug build test clean format check docker-up docker-down spa-dev spa-setup frontend-dev frontend-build e2e e2e-build e2e-run e2e-up e2e-down e2e-wait e2e-test
+.PHONY: help dev dev-spa debug build test clean format check docker-up docker-down spa-dev spa-setup frontend-dev frontend-build e2e e2e-build e2e-run e2e-up e2e-down e2e-wait e2e-test smoke
 
 help: ## Show this help message
 	@echo "$(GREEN)Biblivre Development Shortcuts$(NC)"
@@ -67,6 +67,10 @@ test: ## Run all Java tests
 test-specific: ## Run specific test class (usage: make test-specific TEST=OrderDAOImplTest)
 	@echo "$(GREEN)Running test: $(TEST)$(NC)"
 	@mvn test -P developer -Dtest=$(TEST)
+
+smoke: ## Boot developer-profile server against docker-compose.dev DB, then stop
+	@echo "$(GREEN)Running developer-mode startup smoke...$(NC)"
+	@./scripts/smoke-dev.sh
 
 test-frontend: ## Run frontend tests
 	@echo "$(GREEN)Running frontend tests...$(NC)"

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-aspectj</artifactId>
 		</dependency>
 		<dependency>

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Smoke-start Biblivre the same way local "dev mode" does:
+# docker-compose.dev.yml DB + mvn spring-boot:run with the developer Spring profile.
+#
+# Fails on APPLICATION FAILED TO START (the RestClient.Builder class of bug) and
+# succeeds only after the app reports Started and serves HTTP on SMOKE_PORT.
+#
+# Usage: ./scripts/smoke-dev.sh
+# Env:
+#   SMOKE_PORT   HTTP port (default 18090)
+#   SMOKE_TIMEOUT_SECONDS  max wait (default 180)
+#   SKIP_DB_START  set to 1 to skip docker compose DB bring-up
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SMOKE_PORT="${SMOKE_PORT:-18090}"
+SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-180}"
+SKIP_DB_START="${SKIP_DB_START:-0}"
+LOG_FILE="${TMPDIR:-/tmp}/biblivre-smoke-dev.$$.log"
+MVN_PID=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+stop_server() {
+	if [[ -z "${MVN_PID}" ]]; then
+		return
+	fi
+	echo -e "${YELLOW}Stopping smoke server (pid ${MVN_PID})...${NC}"
+	# spring-boot:run leaves a Java child; kill the Maven tree, then anything
+	# still bound to SMOKE_PORT (portable: no setsid on macOS).
+	if kill -0 "${MVN_PID}" 2>/dev/null; then
+		pkill -TERM -P "${MVN_PID}" 2>/dev/null || true
+		kill -TERM "${MVN_PID}" 2>/dev/null || true
+		wait "${MVN_PID}" 2>/dev/null || true
+	fi
+	if command -v lsof >/dev/null 2>&1; then
+		local listener_pids
+		listener_pids="$(lsof -t -iTCP:"${SMOKE_PORT}" -sTCP:LISTEN 2>/dev/null || true)"
+		if [[ -n "${listener_pids}" ]]; then
+			# shellcheck disable=SC2086
+			kill -TERM ${listener_pids} 2>/dev/null || true
+		fi
+	fi
+	MVN_PID=""
+}
+
+cleanup() {
+	local exit_code=$?
+	stop_server
+	if [[ "${exit_code}" -ne 0 && -f "${LOG_FILE}" ]]; then
+		echo -e "${RED}---- smoke log (tail) ----${NC}"
+		tail -n 80 "${LOG_FILE}" || true
+	fi
+	rm -f "${LOG_FILE}"
+	exit "${exit_code}"
+}
+trap cleanup EXIT INT TERM
+
+ensure_database() {
+	if [[ "${SKIP_DB_START}" == "1" ]]; then
+		echo -e "${YELLOW}SKIP_DB_START=1 — assuming PostgreSQL is already reachable${NC}"
+		return
+	fi
+	echo -e "${GREEN}Ensuring PostgreSQL database is running...${NC}"
+	if ! docker ps --format '{{.Names}}' | grep -q '^biblivre-dev-db$'; then
+		echo -e "${YELLOW}Starting PostgreSQL container...${NC}"
+		docker compose -f docker-compose.dev.yml up -d database
+	else
+		echo -e "${YELLOW}Database container is already running${NC}"
+	fi
+
+	local timeout=60
+	while [[ "${timeout}" -gt 0 ]] &&
+		! docker exec biblivre-dev-db pg_isready -U biblivre -d biblivre4 >/dev/null 2>&1; do
+		sleep 2
+		timeout=$((timeout - 2))
+	done
+	if [[ "${timeout}" -le 0 ]]; then
+		echo -e "${RED}Database failed to become ready within 60 seconds${NC}"
+		exit 1
+	fi
+	echo -e "${GREEN}Database is ready${NC}"
+}
+
+start_server() {
+	export MAVEN_OPTS="${MAVEN_OPTS:--XX:+UnlockExperimentalVMOptions --enable-preview}"
+	export BIBLIVRE_CORS_ENABLED="${BIBLIVRE_CORS_ENABLED:-true}"
+
+	echo -e "${GREEN}Starting Spring Boot (developer profile) on port ${SMOKE_PORT}...${NC}"
+	echo -e "${YELLOW}Log: ${LOG_FILE}${NC}"
+
+	# Keep production-default embedding.provider=openai_compatible (application.yml).
+	# Do not activate the test profile — that switches to hashing and hides this smoke.
+	mvn -B -ntp spring-boot:run \
+		-Dspring-boot.run.profiles=developer \
+		-Dskip.yarn \
+		-Dspring-boot.run.jvmArguments="${MAVEN_OPTS}" \
+		-Dspring-boot.run.arguments="--server.port=${SMOKE_PORT} --spring.devtools.restart.enabled=false --spring.devtools.livereload.enabled=false" \
+		>"${LOG_FILE}" 2>&1 &
+	MVN_PID=$!
+}
+
+await_started() {
+	local deadline=$((SECONDS + SMOKE_TIMEOUT_SECONDS))
+	echo -e "${YELLOW}Waiting up to ${SMOKE_TIMEOUT_SECONDS}s for application start...${NC}"
+
+	while ((SECONDS < deadline)); do
+		if grep -q 'APPLICATION FAILED TO START' "${LOG_FILE}" 2>/dev/null; then
+			echo -e "${RED}Application failed to start${NC}"
+			if grep -q 'RestClient\$Builder' "${LOG_FILE}" 2>/dev/null; then
+				echo -e "${RED}Missing RestClient.Builder bean (add spring-boot-starter-restclient)${NC}"
+			fi
+			exit 1
+		fi
+
+		if grep -qE 'Started .+ in .+ seconds' "${LOG_FILE}" 2>/dev/null; then
+			echo -e "${GREEN}Application reported Started${NC}"
+			return 0
+		fi
+
+		if ! kill -0 "${MVN_PID}" 2>/dev/null; then
+			echo -e "${RED}Maven/Spring Boot process exited before the app started${NC}"
+			exit 1
+		fi
+
+		sleep 2
+	done
+
+	echo -e "${RED}Timed out waiting for application start${NC}"
+	exit 1
+}
+
+http_smoke() {
+	local url="http://127.0.0.1:${SMOKE_PORT}/"
+	echo -e "${YELLOW}HTTP smoke: ${url}${NC}"
+	# Home may redirect; accept any 2xx/3xx.
+	local code
+	code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "${url}" || true)"
+	if [[ ! "${code}" =~ ^[23][0-9][0-9]$ ]]; then
+		echo -e "${RED}Unexpected HTTP status from ${url}: ${code:-none}${NC}"
+		exit 1
+	fi
+	echo -e "${GREEN}HTTP smoke OK (${code})${NC}"
+}
+
+ensure_database
+start_server
+await_started
+http_smoke
+echo -e "${GREEN}Developer-mode smoke passed${NC}"

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -32,20 +32,11 @@ stop_server() {
 		return
 	fi
 	echo -e "${YELLOW}Stopping smoke server (pid ${MVN_PID})...${NC}"
-	# spring-boot:run leaves a Java child; kill the Maven tree, then anything
-	# still bound to SMOKE_PORT (portable: no setsid on macOS).
+	# spring-boot:run leaves a Java child; kill only the Maven process tree.
 	if kill -0 "${MVN_PID}" 2>/dev/null; then
 		pkill -TERM -P "${MVN_PID}" 2>/dev/null || true
 		kill -TERM "${MVN_PID}" 2>/dev/null || true
 		wait "${MVN_PID}" 2>/dev/null || true
-	fi
-	if command -v lsof >/dev/null 2>&1; then
-		local listener_pids
-		listener_pids="$(lsof -t -iTCP:"${SMOKE_PORT}" -sTCP:LISTEN 2>/dev/null || true)"
-		if [[ -n "${listener_pids}" ]]; then
-			# shellcheck disable=SC2086
-			kill -TERM ${listener_pids} 2>/dev/null || true
-		fi
 	fi
 	MVN_PID=""
 }
@@ -91,6 +82,20 @@ ensure_database() {
 start_server() {
 	export MAVEN_OPTS="${MAVEN_OPTS:--XX:+UnlockExperimentalVMOptions --enable-preview}"
 	export BIBLIVRE_CORS_ENABLED="${BIBLIVRE_CORS_ENABLED:-true}"
+
+	if command -v lsof >/dev/null 2>&1; then
+		if lsof -t -iTCP:"${SMOKE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+			echo -e "${RED}Port ${SMOKE_PORT} is already in use. Stop the existing listener and retry.${NC}"
+			exit 1
+		fi
+	elif command -v ss >/dev/null 2>&1; then
+		if ss -H -ltn "sport = :${SMOKE_PORT}" | grep -q .; then
+			echo -e "${RED}Port ${SMOKE_PORT} is already in use. Stop the existing listener and retry.${NC}"
+			exit 1
+		fi
+	else
+		echo -e "${YELLOW}Skipping preflight port check: neither lsof nor ss is available.${NC}"
+	fi
 
 	echo -e "${GREEN}Starting Spring Boot (developer profile) on port ${SMOKE_PORT}...${NC}"
 	echo -e "${YELLOW}Log: ${LOG_FILE}${NC}"

--- a/src/test/java/biblivre/cataloging/search/intelligent/OpenAiCompatibleEmbeddingProviderContextTest.java
+++ b/src/test/java/biblivre/cataloging/search/intelligent/OpenAiCompatibleEmbeddingProviderContextTest.java
@@ -1,0 +1,60 @@
+package biblivre.cataloging.search.intelligent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.restclient.autoconfigure.RestClientAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Smoke for the production-default embedding provider wiring.
+ *
+ * <p>{@code application-test.yml} selects {@code hashing}, so full {@code @SpringBootTest} suites
+ * never load {@link OpenAiCompatibleEmbeddingProvider}. This runner uses the default {@code
+ * openai_compatible} path and fails if {@link RestClient.Builder} is missing (e.g. Boot 4.1+
+ * without {@code spring-boot-starter-restclient} on the main classpath).
+ */
+class OpenAiCompatibleEmbeddingProviderContextTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(RestClientAutoConfiguration.class))
+                    .withBean(IntelligentSearchProperties.class)
+                    .withBean(OpenAiCompatibleEmbeddingProvider.class)
+                    .withPropertyValues(
+                            "biblivre.search.intelligent.embedding.provider=openai_compatible",
+                            "biblivre.search.intelligent.embedding.base-url=http://localhost:11434/v1",
+                            "biblivre.search.intelligent.embedding.api-key=test",
+                            "biblivre.search.intelligent.embedding.model=bge-m3",
+                            "biblivre.search.intelligent.embedding.dimensions=1024");
+
+    @Test
+    void wiresDefaultEmbeddingProviderWhenRestClientBuilderIsAvailable() {
+        contextRunner.run(
+                context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(RestClient.Builder.class);
+                    assertThat(context).hasSingleBean(OpenAiCompatibleEmbeddingProvider.class);
+                    assertThat(context).hasSingleBean(EmbeddingProvider.class);
+                });
+    }
+
+    @Test
+    void failsWithoutRestClientBuilder() {
+        new ApplicationContextRunner()
+                .withBean(IntelligentSearchProperties.class)
+                .withBean(OpenAiCompatibleEmbeddingProvider.class)
+                .withPropertyValues(
+                        "biblivre.search.intelligent.embedding.provider=openai_compatible")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasFailed()
+                                        .getFailure()
+                                        .hasRootCauseInstanceOf(
+                                                NoSuchBeanDefinitionException.class));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `spring-boot-starter-restclient` so Spring Boot 4.1 auto-configures `RestClient.Builder` again (fixes `OpenAiCompatibleEmbeddingProvider` context failure on developer-mode boot).
- Add an `ApplicationContextRunner` smoke that exercises the production-default `openai_compatible` provider path (missed by `@SpringBootTest`, which uses `hashing`).
- Add `scripts/smoke-dev.sh` / `make smoke` and a CI step that boots the real developer-profile server against `docker-compose.dev` DB.

## Test plan
- [x] `mvn test -Dtest=OpenAiCompatibleEmbeddingProviderContextTest -Pdeveloper -Dskip.yarn`
- [x] `./scripts/smoke-dev.sh` (Started + HTTP 200)
- [ ] CI: “Smoke start server (developer mode)” step green on the PR


Made with [Cursor](https://cursor.com)