### PR TITLE
fix: restore OpenAPI /api/v2 base path for SPA REST clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,7 @@
 								<apiPackage>biblivre.reports.generated.api</apiPackage>
 								<modelPackage>biblivre.reports.generated.api.model</modelPackage>
 								<useSpringBoot3>true</useSpringBoot3>
+								<basePath>/api/v2</basePath>
 							</configOptions>
 							<generateModelTests>false</generateModelTests>
 							<generateModelDocumentation>false</generateModelDocumentation>

--- a/src/main/resources/api/report.yaml
+++ b/src/main/resources/api/report.yaml
@@ -3,6 +3,8 @@ info:
   title: Biblivre REST API
   description: |-
   version: 0.0.1
+servers:
+  - url: /api/v2
 paths:
   /userTypes:
     get:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+openapi:
+  biblivreREST:
+    base-path: /api/v2
+
 logging:
   level:
     org:

--- a/src/test/java/biblivre/OpenApiBasePathTest.java
+++ b/src/test/java/biblivre/OpenApiBasePathTest.java
@@ -1,0 +1,22 @@
+package biblivre;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import biblivre.reports.generated.api.CirculationApiController;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+class OpenApiBasePathTest {
+
+    @Test
+    void generatedControllersDefaultBasePathToApiV2() {
+        RequestMapping requestMapping =
+                CirculationApiController.class.getAnnotation(RequestMapping.class);
+
+        assertEquals(
+                "${openapi.biblivreREST.base-path:/api/v2}",
+                requestMapping.value()[0],
+                "Generated OpenAPI controllers must default to /api/v2 so SPA clients keep"
+                        + " working if application.yml omits openapi.biblivreREST.base-path");
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,7 @@
+openapi:
+  biblivreREST:
+    base-path: /api/v2
+
 spring:
   datasource:
     url: jdbc:tc:postgresql:12:///biblivre4


### PR DESCRIPTION
## Summary
- Restores `openapi.biblivreREST.base-path: /api/v2`, accidentally removed in PR #717, so generated Spring controllers match SPA clients under `/api/v2/...`.
- Hardens the OpenAPI generator default (`servers` + Maven `basePath`) and adds a regression test so a missing property cannot silently remount APIs at `/`.

## Test plan
- [x] `mvn -Dtest=OpenApiBasePathTest test -Pdeveloper`
- [x] Start the app and `GET /api/v2/circulation/user_searchable_fields` with `Accept: application/json` and `x-biblivre-schema: single` → `200` JSON
- [x] Open `/spa/circulation_user` while logged in and confirm the searchable-fields request succeeds (no 404)


Made with [Cursor](https://cursor.com)