### PR TITLE
fix: skip intelligent search schema updates when disabled

### DIFF
--- a/src/main/java/biblivre/cataloging/search/intelligent/ConditionalOnIntelligentSearchEnabled.java
+++ b/src/main/java/biblivre/cataloging/search/intelligent/ConditionalOnIntelligentSearchEnabled.java
@@ -1,0 +1,21 @@
+package biblivre.cataloging.search.intelligent;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * Registers the annotated bean only when intelligent search is enabled.
+ *
+ * <p>Schema updates that require pgvector use this so classic-only installs (enabled=false) do not
+ * attempt {@code CREATE EXTENSION vector} or related DDL. Skipped updates are not recorded as
+ * installed, so enabling the feature later applies them on the next boot.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnProperty(name = "biblivre.search.intelligent.enabled", havingValue = "true")
+public @interface ConditionalOnIntelligentSearchEnabled {}

--- a/src/main/java/biblivre/update/v6_0_0$9_0_0$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$9_0_0$alpha/Update.java
@@ -1,5 +1,6 @@
 package biblivre.update.v6_0_0$9_0_0$alpha;
 
+import biblivre.cataloging.search.intelligent.ConditionalOnIntelligentSearchEnabled;
 import biblivre.update.UpdateService;
 import biblivre.update.exception.UpdateException;
 import java.sql.Connection;
@@ -7,6 +8,7 @@ import java.sql.Statement;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnIntelligentSearchEnabled
 public class Update implements UpdateService {
 
     @Override

--- a/src/main/java/biblivre/update/v6_0_0$9_0_1$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$9_0_1$alpha/Update.java
@@ -1,5 +1,6 @@
 package biblivre.update.v6_0_0$9_0_1$alpha;
 
+import biblivre.cataloging.search.intelligent.ConditionalOnIntelligentSearchEnabled;
 import biblivre.update.UpdateService;
 import biblivre.update.exception.UpdateException;
 import java.sql.Connection;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
  * when the column is already vector(768) or the table does not exist yet.
  */
 @Component
+@ConditionalOnIntelligentSearchEnabled
 public class Update implements UpdateService {
 
     @Override

--- a/src/main/java/biblivre/update/v6_0_0$9_0_2$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$9_0_2$alpha/Update.java
@@ -1,5 +1,6 @@
 package biblivre.update.v6_0_0$9_0_2$alpha;
 
+import biblivre.cataloging.search.intelligent.ConditionalOnIntelligentSearchEnabled;
 import biblivre.update.UpdateService;
 import biblivre.update.exception.UpdateException;
 import java.sql.Connection;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 /** Resize biblio_record_search.embedding to 1024 for bge-m3. */
 @Component
+@ConditionalOnIntelligentSearchEnabled
 public class Update implements UpdateService {
 
     @Override

--- a/src/main/java/biblivre/update/v6_0_0$9_0_4$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$9_0_4$alpha/Update.java
@@ -1,5 +1,6 @@
 package biblivre.update.v6_0_0$9_0_4$alpha;
 
+import biblivre.cataloging.search.intelligent.ConditionalOnIntelligentSearchEnabled;
 import biblivre.update.UpdateService;
 import biblivre.update.exception.UpdateException;
 import java.sql.Connection;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 /** Persist RRF relevance on biblio_search_results for intelligent-search ranking. */
 @Component
+@ConditionalOnIntelligentSearchEnabled
 public class Update implements UpdateService {
 
     @Override

--- a/src/test/java/biblivre/cataloging/search/intelligent/ConditionalOnIntelligentSearchEnabledUpdateTest.java
+++ b/src/test/java/biblivre/cataloging/search/intelligent/ConditionalOnIntelligentSearchEnabledUpdateTest.java
@@ -62,7 +62,9 @@ class ConditionalOnIntelligentSearchEnabledUpdateTest {
             },
             useDefaultFilters = false,
             includeFilters =
-                    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UpdateService.class),
+                    @ComponentScan.Filter(
+                            type = FilterType.ASSIGNABLE_TYPE,
+                            classes = UpdateService.class),
             nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
     static class IntelligentSearchUpdates {}
 }

--- a/src/test/java/biblivre/cataloging/search/intelligent/ConditionalOnIntelligentSearchEnabledUpdateTest.java
+++ b/src/test/java/biblivre/cataloging/search/intelligent/ConditionalOnIntelligentSearchEnabledUpdateTest.java
@@ -1,0 +1,68 @@
+package biblivre.cataloging.search.intelligent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import biblivre.update.UpdateService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+
+class ConditionalOnIntelligentSearchEnabledUpdateTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner().withUserConfiguration(IntelligentSearchUpdates.class);
+
+    @Test
+    void registersIntelligentSearchUpdatesWhenEnabled() {
+        contextRunner
+                .withPropertyValues("biblivre.search.intelligent.enabled=true")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context.getBeansOfType(UpdateService.class))
+                                    .hasSize(4)
+                                    .containsKeys(
+                                            "biblivre.update.v6_0_0$9_0_0$alpha.Update",
+                                            "biblivre.update.v6_0_0$9_0_1$alpha.Update",
+                                            "biblivre.update.v6_0_0$9_0_2$alpha.Update",
+                                            "biblivre.update.v6_0_0$9_0_4$alpha.Update");
+                        });
+    }
+
+    @Test
+    void skipsIntelligentSearchUpdatesWhenDisabled() {
+        contextRunner
+                .withPropertyValues("biblivre.search.intelligent.enabled=false")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+                            assertThat(context.getBeansOfType(UpdateService.class)).isEmpty();
+                        });
+    }
+
+    @Test
+    void skipsIntelligentSearchUpdatesWhenPropertyMissing() {
+        contextRunner.run(
+                context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBeansOfType(UpdateService.class)).isEmpty();
+                });
+    }
+
+    @Configuration
+    @ComponentScan(
+            basePackages = {
+                "biblivre.update.v6_0_0$9_0_0$alpha",
+                "biblivre.update.v6_0_0$9_0_1$alpha",
+                "biblivre.update.v6_0_0$9_0_2$alpha",
+                "biblivre.update.v6_0_0$9_0_4$alpha"
+            },
+            useDefaultFilters = false,
+            includeFilters =
+                    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UpdateService.class),
+            nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+    static class IntelligentSearchUpdates {}
+}


### PR DESCRIPTION
## Summary
- Gate pgvector-related schema updates (`9_0_0`–`9_0_2`, `9_0_4`) behind `biblivre.search.intelligent.enabled=true`
- Classic-only installs no longer attempt `CREATE EXTENSION vector` at boot when the feature is off (the default)
- Skipped updates are not marked installed, so enabling the feature later still applies them on the next boot

## Test plan
- [x] `mvn -P developer -Dtest=ConditionalOnIntelligentSearchEnabledUpdateTest test`
- [ ] Boot app against Postgres without pgvector and `BIBLIVRE_SEARCH_INTELLIGENT_ENABLED=false` (or unset) — startup succeeds
- [ ] With `BIBLIVRE_SEARCH_INTELLIGENT_ENABLED=true` and pgvector installed — updates `9_0_0`+ still apply


Made with [Cursor](https://cursor.com)