### PR TITLE
fix: clear legacy CEP lookup loading overlay

### DIFF
--- a/src/main/resources/META-INF/resources/static/scripts/biblivre.circulation.input.js
+++ b/src/main/resources/META-INF/resources/static/scripts/biblivre.circulation.input.js
@@ -451,6 +451,8 @@ var CirculationInput = new Input({
 		cepInput.prop('disabled', true);
 		lookupButton.addClass('disabled').attr('aria-disabled', 'true');
 
+		// Do not pass a local `complete` option: in jQuery 1.7 it replaces
+		// $.ajaxSetup's complete, so Core.hideLoadingTimedOverlay never runs.
 		$.ajax({
 			url: `${window.location.origin}${this.contextPath || ''}/api/v2/circulation/address_lookup/${encodeURIComponent(normalizedCep)}`,
 			type: 'GET',
@@ -492,11 +494,10 @@ var CirculationInput = new Input({
 					message_level: 'error',
 				});
 			},
-			complete: () => {
-				this._addressLookupInFlight = false;
-				cepInput.prop('disabled', false);
-				lookupButton.removeClass('disabled').removeAttr('aria-disabled');
-			},
+		}).always(() => {
+			this._addressLookupInFlight = false;
+			cepInput.prop('disabled', false);
+			lookupButton.removeClass('disabled').removeAttr('aria-disabled');
 		});
 	},
 });


### PR DESCRIPTION
## Summary
- Legacy CEP lookup left the page stuck on the loading overlay after a successful (or failed) address search.
- jQuery 1.7 replaces `$.ajaxSetup({ complete })` when a local `complete` option is passed, so `Core.hideLoadingTimedOverlay` never ran.
- Move post-request cleanup to `.always()` and keep `loadingTimedOverlay` so the global complete still hides the overlay.

## Test plan
- [x] Open legacy Circulação → Cadastro de Usuários with address lookup enabled
- [x] Enter a valid CEP (e.g. `50740420`) and click Buscar
- [x] Confirm address fields fill and the loading overlay disappears
- [x] Repeat with address fields already filled and confirm overwrite dialog still works after the overlay clears
- [x] Repeat with an invalid/not-found CEP and confirm the overlay clears and an error message is shown


Made with [Cursor](https://cursor.com)