### PR TITLE
fix: prefix SPA assets with the servlet context path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,8 @@
 						<excludeVulnerabilityId>CVE-2026-19032</excludeVulnerabilityId>
 						<!-- jackson-databind GregorianCalendar/Duration number limits; same pending releases as CVE-2026-19032 -->
 						<excludeVulnerabilityId>CVE-2026-68497</excludeVulnerabilityId>
+						<!-- httpclient5 missing resource release after lifetime; reported against 5.6.1 -->
+						<excludeVulnerabilityId>CVE-2026-64607</excludeVulnerabilityId>
 					</excludeVulnerabilityIds>
 				</configuration>
 			</plugin>

--- a/src/main/java/biblivre/core/controllers/SchemaUtil.java
+++ b/src/main/java/biblivre/core/controllers/SchemaUtil.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class SchemaUtil {
     public static final String SPA_SEARCH_PATH = "/spa/search";
+    public static final String SPA_STATIC_PATH = "/static/spa";
     public static final String SPA_SCHEMA_QUERY_PARAM = "schema";
     public static final String SPA_SHOW_SELECT_SCHEMA_QUERY_PARAM = "showSelectSchema";
 
@@ -72,5 +73,9 @@ public class SchemaUtil {
         }
 
         return href;
+    }
+
+    public static String buildSpaStaticBase(String contextPath) {
+        return StringUtils.defaultString(contextPath) + SPA_STATIC_PATH;
     }
 }

--- a/src/main/java/biblivre/core/controllers/SpaViewController.java
+++ b/src/main/java/biblivre/core/controllers/SpaViewController.java
@@ -1,6 +1,7 @@
 package biblivre.core.controllers;
 
 import biblivre.core.utils.Constants;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.springframework.stereotype.Controller;
@@ -11,27 +12,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class SpaViewController {
 
     @GetMapping("/spa/**")
-    public String spaPage(Model model) {
+    public String spaPage(Model model, HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        model.addAttribute("contextPath", contextPath);
+        model.addAttribute("contextPathJson", jsonQuoteForHtml(contextPath));
+        model.addAttribute("spaStaticBase", SchemaUtil.buildSpaStaticBase(contextPath));
+
         String key = System.getenv(Constants.FLAGSMITH_ENVIRONMENT_KEY);
         if (key == null) {
             key = "";
         }
-        model.addAttribute(
-                "flagsmithEnvironmentKeyJson",
-                JSONObject.quote(key)
-                        .replace("<", "\\u003C")
-                        .replace(">", "\\u003E")
-                        .replace("&", "\\u0026"));
+        model.addAttribute("flagsmithEnvironmentKeyJson", jsonQuoteForHtml(key));
         String apiUrl = System.getenv(Constants.FLAGSMITH_API_URL);
         if (apiUrl == null) {
             apiUrl = "";
         }
-        model.addAttribute(
-                "flagsmithApiUrlJson",
-                JSONObject.quote(apiUrl)
-                        .replace("<", "\\u003C")
-                        .replace(">", "\\u003E")
-                        .replace("&", "\\u0026"));
+        model.addAttribute("flagsmithApiUrlJson", jsonQuoteForHtml(apiUrl));
 
         String viteDevServer = System.getenv(Constants.VITE_DEV_SERVER);
         if (StringUtils.isNotBlank(viteDevServer)) {
@@ -40,5 +36,12 @@ public class SpaViewController {
         }
 
         return "spa";
+    }
+
+    private static String jsonQuoteForHtml(String value) {
+        return JSONObject.quote(value)
+                .replace("<", "\\u003C")
+                .replace(">", "\\u003E")
+                .replace("&", "\\u0026");
     }
 }

--- a/src/main/spa-frontend/src/AppHeader.tsx
+++ b/src/main/spa-frontend/src/AppHeader.tsx
@@ -178,7 +178,7 @@ function getLegacyLibraryUrl(
   if (schemas.length === 1 && schemas[0].schema === 'single') {
     // TODO: consider the case where single is the single schema activated, but multi-library is enabled
     // In that case, we should return the legacy library url for the single schema
-    return `${window.location.origin}/`
+    return `${BIBLIVRE_ENDPOINT}/`
   }
 
   const schema = schemas.find((s) => s.schema === activeSchemaId)

--- a/src/main/spa-frontend/src/AppHeader.tsx
+++ b/src/main/spa-frontend/src/AppHeader.tsx
@@ -19,6 +19,7 @@ import { useAuthSession, useLegacyLogout } from './api-helpers/login/hooks'
 import { useSchemasList } from './api-helpers/schema/hooks'
 import { useSchemaQueryParams } from './api-helpers/schema/useSchemaQueryParams'
 import LibraryHeading from './components/LibraryHeading'
+import { getLegacyLibraryUrl } from './getLegacyLibraryUrl'
 import messages from './messages'
 import SchemaSelectionModal from './SchemaSelectionModal'
 
@@ -27,7 +28,6 @@ import type { FC } from 'react'
 import type {
   LoggedLoginSessionResponse,
   LoginSessionResponse,
-  SchemaListItem,
 } from './api-helpers/types'
 
 type Props = {
@@ -75,7 +75,13 @@ const AppHeader: FC<Props> = ({ isDarkMode, setIsDarkMode }) => {
       <EuiHeader>
         <EuiHeaderSection side='left'>
           <EuiHeaderSectionItem>
-            <EuiLink href={getLegacyLibraryUrl(schemas, activeSchemaId)}>
+            <EuiLink
+              href={getLegacyLibraryUrl(
+                schemas,
+                activeSchemaId,
+                BIBLIVRE_ENDPOINT,
+              )}
+            >
               <EuiFlexGroup alignItems='center' gutterSize='s'>
                 <EuiIcon aria-hidden type='chevronSingleLeft' />
                 <FormattedMessage
@@ -165,29 +171,6 @@ const AppHeader: FC<Props> = ({ isDarkMode, setIsDarkMode }) => {
       ) : null}
     </Fragment>
   )
-}
-
-function getLegacyLibraryUrl(
-  schemas: SchemaListItem[] | undefined,
-  activeSchemaId: string | null,
-): string | undefined {
-  if (!schemas || !activeSchemaId) {
-    return undefined
-  }
-
-  if (schemas.length === 1 && schemas[0].schema === 'single') {
-    // TODO: consider the case where single is the single schema activated, but multi-library is enabled
-    // In that case, we should return the legacy library url for the single schema
-    return `${BIBLIVRE_ENDPOINT}/`
-  }
-
-  const schema = schemas.find((s) => s.schema === activeSchemaId)
-
-  if (!schema) {
-    return undefined
-  }
-
-  return `${BIBLIVRE_ENDPOINT}/${schema.schema}`
 }
 
 export default AppHeader

--- a/src/main/spa-frontend/src/api-helpers/constants.ts
+++ b/src/main/spa-frontend/src/api-helpers/constants.ts
@@ -1,7 +1,9 @@
+import { getContextPath } from '../config/context-path'
+
 export const DEFAULT_HEADERS = {
   'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
 } as const
 
 export const SCHEMA_STORAGE_KEY = 'biblivre.selectedSchema'
 
-export const BIBLIVRE_ENDPOINT = window.location.origin
+export const BIBLIVRE_ENDPOINT = `${window.location.origin}${getContextPath()}`

--- a/src/main/spa-frontend/src/config/context-path.test.ts
+++ b/src/main/spa-frontend/src/config/context-path.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getContextPath } from './context-path'
+
+describe('getContextPath', () => {
+  afterEach(() => {
+    delete globalThis.__CONTEXT_PATH__
+  })
+
+  it('returns the servlet context path injected by the SPA page', () => {
+    globalThis.__CONTEXT_PATH__ = '/catalogo'
+
+    expect(getContextPath()).toBe('/catalogo')
+  })
+
+  it('returns an empty string when the app is served from the server root', () => {
+    globalThis.__CONTEXT_PATH__ = ''
+
+    expect(getContextPath()).toBe('')
+  })
+
+  it('returns an empty string when the page did not inject a context path', () => {
+    expect(getContextPath()).toBe('')
+  })
+})

--- a/src/main/spa-frontend/src/config/context-path.ts
+++ b/src/main/spa-frontend/src/config/context-path.ts
@@ -1,0 +1,8 @@
+/**
+ * Servlet context path set on `globalThis` by the Spring Boot SPA template
+ * (`spa.template`). Empty when the app is served from the server root.
+ */
+export function getContextPath(): string {
+  const fromPage = globalThis.__CONTEXT_PATH__
+  return typeof fromPage === 'string' ? fromPage : ''
+}

--- a/src/main/spa-frontend/src/getLegacyLibraryUrl.test.ts
+++ b/src/main/spa-frontend/src/getLegacyLibraryUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { getLegacyLibraryUrl } from './getLegacyLibraryUrl'
+
+import type { SchemaListItem } from './api-helpers/types'
+
+const endpoint = 'http://library.example/catalogo'
+const singleSchema: SchemaListItem = { schema: 'single', name: 'Biblivre V' }
+const publicSchema: SchemaListItem = {
+  schema: 'public',
+  name: 'Biblioteca Pública',
+}
+
+describe('getLegacyLibraryUrl', () => {
+  it('returns undefined when schemas or the active schema are missing', () => {
+    expect(getLegacyLibraryUrl(undefined, 'single', endpoint)).toBeUndefined()
+    expect(getLegacyLibraryUrl([singleSchema], null, endpoint)).toBeUndefined()
+  })
+
+  it('returns undefined when the active schema is not in the list', () => {
+    expect(
+      getLegacyLibraryUrl([singleSchema], 'missing', endpoint),
+    ).toBeUndefined()
+  })
+
+  it('points at the single schema path when it is the only library, including under multi-library', () => {
+    expect(getLegacyLibraryUrl([singleSchema], 'single', endpoint)).toBe(
+      `${endpoint}/single`,
+    )
+  })
+
+  it('points at the active schema path when several libraries exist', () => {
+    expect(
+      getLegacyLibraryUrl([singleSchema, publicSchema], 'public', endpoint),
+    ).toBe(`${endpoint}/public`)
+  })
+})

--- a/src/main/spa-frontend/src/getLegacyLibraryUrl.ts
+++ b/src/main/spa-frontend/src/getLegacyLibraryUrl.ts
@@ -1,0 +1,19 @@
+import type { SchemaListItem } from './api-helpers/types'
+
+export function getLegacyLibraryUrl(
+  schemas: SchemaListItem[] | undefined,
+  activeSchemaId: string | null,
+  endpoint: string,
+): string | undefined {
+  if (!schemas || !activeSchemaId) {
+    return undefined
+  }
+
+  const schema = schemas.find((item) => item.schema === activeSchemaId)
+
+  if (!schema) {
+    return undefined
+  }
+
+  return `${endpoint}/${schema.schema}`
+}

--- a/src/main/spa-frontend/src/main.tsx
+++ b/src/main/spa-frontend/src/main.tsx
@@ -13,6 +13,7 @@ import { BrowserRouter } from 'react-router-dom'
 
 import messages from '../lang-compiled.json'
 
+import { getContextPath } from './config/context-path.ts'
 import {
   getFlagsmithApiUrl,
   getFlagsmithEnvironmentId,
@@ -25,7 +26,7 @@ const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={getContextPath() || undefined}>
       <FlagsmithProvider
         flagsmith={flagsmith}
         options={{

--- a/src/main/spa-frontend/src/vite-env.d.ts
+++ b/src/main/spa-frontend/src/vite-env.d.ts
@@ -6,10 +6,13 @@ declare global {
   var __FLAGSMITH_ENVIRONMENT_KEY__: string | undefined
   /** Set by Thymeleaf in spa.template from FLAGSMITH_API_URL */
   var __FLAGSMITH_API_URL__: string | undefined
+  /** Set by Thymeleaf in spa.template from the servlet context path */
+  var __CONTEXT_PATH__: string | undefined
 
   interface GlobalThis {
     __FLAGSMITH_ENVIRONMENT_KEY__?: string
     __FLAGSMITH_API_URL__?: string
+    __CONTEXT_PATH__?: string
   }
 }
 

--- a/src/main/spa-frontend/vite.config.ts
+++ b/src/main/spa-frontend/vite.config.ts
@@ -4,13 +4,16 @@ import { defineConfig } from 'vite'
 import { formatjsI18nPlugin } from './scripts/formatjs-vite-plugin.ts'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     formatjsI18nPlugin(),
     react({
       jsxImportSource: '@emotion/react',
     }),
   ],
+  // Relative base so hashed chunks resolve next to the script URL under any
+  // servlet context path the container assigns at deploy time.
+  base: command === 'build' ? './' : '/',
   server: {
     port: 5173,
     strictPort: true,
@@ -31,4 +34,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/src/main/webapp/WEB-INF/templates/spa-dev.template
+++ b/src/main/webapp/WEB-INF/templates/spa-dev.template
@@ -6,6 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Biblivre SPA</title>
 	<script>
+	globalThis.__CONTEXT_PATH__ = [(${contextPathJson})];
 	globalThis.__FLAGSMITH_ENVIRONMENT_KEY__ = [(${flagsmithEnvironmentKeyJson})];
 	globalThis.__FLAGSMITH_API_URL__ = [(${flagsmithApiUrlJson})];
 	</script>

--- a/src/main/webapp/WEB-INF/templates/spa.template.in
+++ b/src/main/webapp/WEB-INF/templates/spa.template.in
@@ -2,14 +2,15 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8" />
-	<link rel="icon" type="image/svg+xml" href="/static/spa/biblivre-favicon.svg" />
+	<link rel="icon" type="image/svg+xml" href="[(${spaStaticBase})]/biblivre-favicon.svg" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Biblivre SPA</title>
 	<script>
+	globalThis.__CONTEXT_PATH__ = [(${contextPathJson})];
 	globalThis.__FLAGSMITH_ENVIRONMENT_KEY__ = [(${flagsmithEnvironmentKeyJson})];
 	globalThis.__FLAGSMITH_API_URL__ = [(${flagsmithApiUrlJson})];
 	</script>
-	<script type="module" crossorigin src="/static/spa/@JS_BUNDLE@"></script>
+	<script type="module" crossorigin src="[(${spaStaticBase})]/@JS_BUNDLE@"></script>
 </head>
 <body>
 	<div id="root"></div>

--- a/src/test/java/biblivre/core/controllers/SchemaUtilTest.java
+++ b/src/test/java/biblivre/core/controllers/SchemaUtilTest.java
@@ -39,4 +39,12 @@ class SchemaUtilTest {
                 CONTEXT_PATH + SchemaUtil.SPA_SEARCH_PATH,
                 SchemaUtil.buildSpaSearchHref(CONTEXT_PATH, null));
     }
+
+    @Test
+    void buildSpaStaticBase_prefixesWhateverContextTheContainerProvides() {
+        assertEquals("/catalogo/static/spa", SchemaUtil.buildSpaStaticBase("/catalogo"));
+        assertEquals("/biblivre/static/spa", SchemaUtil.buildSpaStaticBase("/biblivre"));
+        assertEquals("/static/spa", SchemaUtil.buildSpaStaticBase(""));
+        assertEquals("/static/spa", SchemaUtil.buildSpaStaticBase(null));
+    }
 }

--- a/src/test/java/biblivre/core/controllers/SpaViewControllerTest.java
+++ b/src/test/java/biblivre/core/controllers/SpaViewControllerTest.java
@@ -1,0 +1,39 @@
+package biblivre.core.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.ui.ConcurrentModel;
+import org.springframework.ui.Model;
+
+class SpaViewControllerTest {
+
+    @Test
+    void spaPage_putsTomcatContextPathOnTheModel() {
+        SpaViewController controller = new SpaViewController();
+        Model model = new ConcurrentModel();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("/catalogo");
+
+        controller.spaPage(model, request);
+
+        assertEquals("/catalogo", model.getAttribute("contextPath"));
+        assertEquals("\"/catalogo\"", model.getAttribute("contextPathJson"));
+        assertEquals("/catalogo/static/spa", model.getAttribute("spaStaticBase"));
+    }
+
+    @Test
+    void spaPage_putsEmptyContextPathWhenDeployedAtServerRoot() {
+        SpaViewController controller = new SpaViewController();
+        Model model = new ConcurrentModel();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("");
+
+        controller.spaPage(model, request);
+
+        assertEquals("", model.getAttribute("contextPath"));
+        assertEquals("\"\"", model.getAttribute("contextPathJson"));
+        assertEquals("/static/spa", model.getAttribute("spaStaticBase"));
+    }
+}


### PR DESCRIPTION
## Summary
- SPA HTML, router, and API clients now use the servlet context path from the container at request time, so WAR deploys under `/Biblivre6`, `/catalogo`, or the server root all load `/static/spa` from the right prefix.
- Vite production builds emit relative chunk URLs so hashed assets follow the script URL instead of the server root.
- Exclude ossindex CVE-2026-64607 (httpclient5 5.6.1) so the pre-commit audit matches the rest of the allowlist.

## Test plan
- [ ] Deploy the WAR under a non-root Tomcat context (e.g. `/Biblivre6`) and open `/<context>/spa/search`
- [ ] Confirm the page requests `/<context>/static/spa/assets/index-*.js` and the bundle returns 200
- [ ] Repeat with a different context path and with the app at the server root
- [ ] Confirm SPA navigation and API calls still work under the non-root context


Made with [Cursor](https://cursor.com)