### PR TITLE
ci: skip the second Maven lifecycle and smoke from the packaged WAR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
 # CI + Docker publish for Biblivre
 #
-# PRs: build and test.
-# Push to master / tags master-*: build, test, package, then publish Docker image
-# from the packaged artifact (no second Maven run).
+# PRs and pushes: Maven package (includes tests). Push to master / tags master-*
+# then publishes a Docker image from the packaged artifact (no second Maven run).
 
 name: CI
 
@@ -87,13 +86,20 @@ jobs:
           restore-keys: |
             dart-sass-${{ runner.os }}-
 
+      # package already runs tests. `mvn test package` would execute generate-resources
+      # (Yarn/Vite) and compile twice. Pull Testcontainers (pg16, see
+      # SharedPostgreSQLContainer) + smoke DB (pg18) in the background so
+      # surefire/smoke do not wait on docker pull after Maven.
       - name: Build with Maven
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            mvn -B -ntp clean test -Pgithub-ci
-          else
-            mvn -B -ntp clean test package -Pgithub-ci
-          fi
+          docker pull pgvector/pgvector:pg16 >/tmp/docker-pull-pg16.log 2>&1 &
+          docker compose -f docker-compose.dev.yml up -d database >/tmp/docker-compose-smoke-db.log 2>&1 &
+          mvn -B -ntp clean package -Pgithub-ci
+          wait || true
+          echo "---- docker pull pg16 ----"
+          cat /tmp/docker-pull-pg16.log || true
+          echo "---- docker compose smoke db ----"
+          cat /tmp/docker-compose-smoke-db.log || true
 
       # Real process boot (developer Spring profile + docker-compose.dev DB), not
       # @SpringBootTest/test profile — catches missing runtime beans such as

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ debug: ## Run Spring Boot application with debug port 5005 exposed
 	@echo "$(GREEN)Starting Spring Boot application with debug on port 5005...$(NC)"
 	@echo "$(YELLOW)Connect your IDE debugger to localhost:5005$(NC)"
 	@set -a; [ -f .env.dev ] && . ./.env.dev; set +a; \
-	export MAVEN_OPTS="$(MAVEN_OPTS) $(DEBUG_OPTS)" BIBLIVRE_CORS_ENABLED=true && mvn spring-boot:run -Dspring-boot.run.profiles=developer -Dskip.yarn
+	export MAVEN_OPTS="$(MAVEN_OPTS) $(DEBUG_OPTS)" BIBLIVRE_CORS_ENABLED=true && mvn spring-boot:run -Dspring-boot.run.profiles=developer -Dskip.yarn=true
 
 debug-suspend: ## Run Spring Boot application with debug port 5005, suspend until debugger connects
 	@$(MAKE) db-start

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 		<jackson-2-bom.version>2.21.5</jackson-2-bom.version>
 		<jackson-bom.version>3.1.5</jackson-bom.version>
 		<log4j2.version>2.25.5</log4j2.version>
+		<skip.yarn>false</skip.yarn>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -549,6 +550,9 @@
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
 				<version>2.0.2</version>
+				<configuration>
+					<skip>${skip.yarn}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>install node and corepack spa-frontend</id>

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Smoke-start Biblivre the same way local "dev mode" does:
-# docker-compose.dev.yml DB + mvn spring-boot:run with the developer Spring profile.
+# Smoke-start Biblivre against docker-compose.dev.yml DB.
+# Prefers the packaged WAR (java -jar) so CI does not pay a second Maven
+# generate-resources/Yarn cycle; falls back to spring-boot:run for local use.
 #
 # Fails on APPLICATION FAILED TO START (the RestClient.Builder class of bug) and
 # succeeds only after the app reports Started and serves HTTP on SMOKE_PORT.
@@ -20,7 +21,8 @@ SMOKE_PORT="${SMOKE_PORT:-18090}"
 SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-180}"
 SKIP_DB_START="${SKIP_DB_START:-0}"
 LOG_FILE="${TMPDIR:-/tmp}/biblivre-smoke-dev.$$.log"
-MVN_PID=""
+SERVER_PID=""
+PACKAGED_WAR="${ROOT_DIR}/target/Biblivre6.war"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -28,17 +30,18 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 stop_server() {
-	if [[ -z "${MVN_PID}" ]]; then
+	if [[ -z "${SERVER_PID}" ]]; then
 		return
 	fi
-	echo -e "${YELLOW}Stopping smoke server (pid ${MVN_PID})...${NC}"
-	# spring-boot:run leaves a Java child; kill only the Maven process tree.
-	if kill -0 "${MVN_PID}" 2>/dev/null; then
-		pkill -TERM -P "${MVN_PID}" 2>/dev/null || true
-		kill -TERM "${MVN_PID}" 2>/dev/null || true
-		wait "${MVN_PID}" 2>/dev/null || true
+	echo -e "${YELLOW}Stopping smoke server (pid ${SERVER_PID})...${NC}"
+	# spring-boot:run leaves a Java child; kill the Maven process tree. java -jar
+	# is a single process — pkill is a no-op when there are no children.
+	if kill -0 "${SERVER_PID}" 2>/dev/null; then
+		pkill -TERM -P "${SERVER_PID}" 2>/dev/null || true
+		kill -TERM "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
 	fi
-	MVN_PID=""
+	SERVER_PID=""
 }
 
 cleanup() {
@@ -97,18 +100,34 @@ start_server() {
 		echo -e "${YELLOW}Skipping preflight port check: neither lsof nor ss is available.${NC}"
 	fi
 
-	echo -e "${GREEN}Starting Spring Boot (developer profile) on port ${SMOKE_PORT}...${NC}"
 	echo -e "${YELLOW}Log: ${LOG_FILE}${NC}"
 
 	# Keep production-default embedding.provider=openai_compatible (application.yml).
 	# Do not activate the test profile — that switches to hashing and hides this smoke.
+	local -a run_arguments=(
+		"--server.port=${SMOKE_PORT}"
+		"--spring.devtools.restart.enabled=false"
+		"--spring.devtools.livereload.enabled=false"
+		"--spring.profiles.active=developer"
+	)
+
+	if [[ -f "${PACKAGED_WAR}" ]]; then
+		echo -e "${GREEN}Starting packaged app on port ${SMOKE_PORT}...${NC}"
+		# shellcheck disable=SC2086
+		java ${MAVEN_OPTS} -jar "${PACKAGED_WAR}" "${run_arguments[@]}" >"${LOG_FILE}" 2>&1 &
+		SERVER_PID=$!
+		return
+	fi
+
+	echo -e "${GREEN}Starting Spring Boot (developer profile) on port ${SMOKE_PORT}...${NC}"
 	mvn -B -ntp spring-boot:run \
 		-Dspring-boot.run.profiles=developer \
-		-Dskip.yarn \
+		-Dskip.yarn=true \
+		-Dopenapi.generator.maven.plugin.skip=true \
 		-Dspring-boot.run.jvmArguments="${MAVEN_OPTS}" \
-		-Dspring-boot.run.arguments="--server.port=${SMOKE_PORT} --spring.devtools.restart.enabled=false --spring.devtools.livereload.enabled=false" \
+		-Dspring-boot.run.arguments="${run_arguments[*]}" \
 		>"${LOG_FILE}" 2>&1 &
-	MVN_PID=$!
+	SERVER_PID=$!
 }
 
 await_started() {
@@ -129,8 +148,8 @@ await_started() {
 			return 0
 		fi
 
-		if ! kill -0 "${MVN_PID}" 2>/dev/null; then
-			echo -e "${RED}Maven/Spring Boot process exited before the app started${NC}"
+		if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+			echo -e "${RED}Smoke server process exited before the app started${NC}"
 			exit 1
 		fi
 


### PR DESCRIPTION
## Summary
- Stop running `mvn test package` (two default-lifecycle goals), which rebuilt Yarn/Vite and recompiled before `package`.
- Pull Testcontainers (`pg16`) and the smoke DB (`pg18`) while Maven runs so surefire/smoke do not wait on Docker afterwards.
- Boot the CI smoke server from `target/Biblivre6.war` instead of a second `spring-boot:run`, and honor `-Dskip.yarn=true` in the frontend plugin.

## Test plan
- [x] Confirm the CI `build` job on this PR completes and is faster than the previous ~2m 45s master run
- [ ] Check Maven logs: generate-resources / Yarn / compile appear once, then `war` + `repackage`
- [ ] Confirm smoke logs say `Starting packaged app` (java -jar), not `spring-boot:run`
- [x] Confirm Testcontainers tests still pass (pg16 pull overlapped with Maven)


Made with [Cursor](https://cursor.com)