### PR TITLE
fix: post legacy SPA requests to the context root with a slash

### DIFF
--- a/src/main/spa-frontend/src/api-helpers/index.ts
+++ b/src/main/spa-frontend/src/api-helpers/index.ts
@@ -1,3 +1,5 @@
+import { getLegacyRootUrl } from '../getLegacyLibraryUrl'
+
 import { getStoredSchema } from './schema/storage'
 import { BIBLIVRE_ENDPOINT, DEFAULT_HEADERS } from './constants'
 
@@ -28,7 +30,7 @@ export async function fetchJSONFromLegacyEndpoint({
   action,
   ...otherParams
 }: ParametrizedLegacyEndpointPayloadValues) {
-  const response = await fetch(BIBLIVRE_ENDPOINT, {
+  const response = await fetch(getLegacyRootUrl(BIBLIVRE_ENDPOINT), {
     method: 'POST',
     headers: buildDefaultHeaders(),
     body: new URLSearchParams({
@@ -54,9 +56,12 @@ export async function downloadFromLegacyEndpoint({
     ...otherParams,
   }).toString()
 
-  const response = await fetch(`${BIBLIVRE_ENDPOINT}?${queryParams}`, {
-    headers: buildDefaultHeaders(),
-  })
+  const response = await fetch(
+    `${getLegacyRootUrl(BIBLIVRE_ENDPOINT)}?${queryParams}`,
+    {
+      headers: buildDefaultHeaders(),
+    },
+  )
 
   return {
     blob: await response.blob(),

--- a/src/main/spa-frontend/src/api-helpers/legacy-endpoint.test.ts
+++ b/src/main/spa-frontend/src/api-helpers/legacy-endpoint.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getLegacyRootUrl } from '../getLegacyLibraryUrl'
+
+import { BIBLIVRE_ENDPOINT } from './constants'
+import { downloadFromLegacyEndpoint, fetchJSONFromLegacyEndpoint } from '.'
+
+describe('legacy form endpoint', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts JSON actions to the context root with a trailing slash', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ success: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchJSONFromLegacyEndpoint({
+      module: 'multi_schema',
+      action: 'list',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      getLegacyRootUrl(BIBLIVRE_ENDPOINT),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(String(fetchMock.mock.calls[0][0])).toMatch(/\/$/)
+  })
+
+  it('downloads from the context root with a trailing slash', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      blob: async () => new Blob(),
+      headers: { get: () => null },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await downloadFromLegacyEndpoint({
+      module: 'cataloging.bibliographic',
+      action: 'download_export',
+      id: 'export-id',
+    })
+
+    const requestedUrl = String(fetchMock.mock.calls[0][0])
+    expect(requestedUrl.startsWith(getLegacyRootUrl(BIBLIVRE_ENDPOINT))).toBe(
+      true,
+    )
+    expect(requestedUrl).toContain('controller=download')
+  })
+})

--- a/src/main/spa-frontend/src/getLegacyLibraryUrl.test.ts
+++ b/src/main/spa-frontend/src/getLegacyLibraryUrl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getLegacyLibraryUrl } from './getLegacyLibraryUrl'
+import { getLegacyLibraryUrl, getLegacyRootUrl } from './getLegacyLibraryUrl'
 
 import type { SchemaListItem } from './api-helpers/types'
 
@@ -11,16 +11,33 @@ const publicSchema: SchemaListItem = {
   name: 'Biblioteca Pública',
 }
 
-describe('getLegacyLibraryUrl', () => {
-  it('returns undefined when schemas or the active schema are missing', () => {
-    expect(getLegacyLibraryUrl(undefined, 'single', endpoint)).toBeUndefined()
-    expect(getLegacyLibraryUrl([singleSchema], null, endpoint)).toBeUndefined()
+describe('getLegacyRootUrl', () => {
+  it('adds a trailing slash so POST does not bounce off the context path', () => {
+    expect(getLegacyRootUrl(endpoint)).toBe(`${endpoint}/`)
+    expect(getLegacyRootUrl('http://library.example')).toBe(
+      'http://library.example/',
+    )
   })
 
-  it('returns undefined when the active schema is not in the list', () => {
-    expect(
-      getLegacyLibraryUrl([singleSchema], 'missing', endpoint),
-    ).toBeUndefined()
+  it('keeps a trailing slash that is already present', () => {
+    expect(getLegacyRootUrl(`${endpoint}/`)).toBe(`${endpoint}/`)
+  })
+})
+
+describe('getLegacyLibraryUrl', () => {
+  it('falls back to the classic root when schemas or the active schema are missing', () => {
+    expect(getLegacyLibraryUrl(undefined, 'single', endpoint)).toBe(
+      `${endpoint}/`,
+    )
+    expect(getLegacyLibraryUrl([singleSchema], null, endpoint)).toBe(
+      `${endpoint}/`,
+    )
+  })
+
+  it('falls back to the classic root when the active schema is not in the list', () => {
+    expect(getLegacyLibraryUrl([singleSchema], 'missing', endpoint)).toBe(
+      `${endpoint}/`,
+    )
   })
 
   it('points at the single schema path when it is the only library, including under multi-library', () => {

--- a/src/main/spa-frontend/src/getLegacyLibraryUrl.ts
+++ b/src/main/spa-frontend/src/getLegacyLibraryUrl.ts
@@ -1,19 +1,25 @@
 import type { SchemaListItem } from './api-helpers/types'
 
+export function getLegacyRootUrl(endpoint: string): string {
+  return endpoint.endsWith('/') ? endpoint : `${endpoint}/`
+}
+
 export function getLegacyLibraryUrl(
   schemas: SchemaListItem[] | undefined,
   activeSchemaId: string | null,
   endpoint: string,
-): string | undefined {
+): string {
+  const rootUrl = getLegacyRootUrl(endpoint)
+
   if (!schemas || !activeSchemaId) {
-    return undefined
+    return rootUrl
   }
 
   const schema = schemas.find((item) => item.schema === activeSchemaId)
 
   if (!schema) {
-    return undefined
+    return rootUrl
   }
 
-  return `${endpoint}/${schema.schema}`
+  return `${endpoint.replace(/\/$/, '')}/${schema.schema}`
 }


### PR DESCRIPTION
## Summary
- Tomcat redirects `/{context}` to `/{context}/`, so SPA `fetch` POSTs to `/Biblivre6` were followed as GETs of HTML. The schema list never loaded and **Voltar para a interface clássica** rendered as a button with no `href`.
- POST/download calls now use the context root with a trailing slash. If no library is selected, the back-to-classic link falls back to that same root instead of staying dead.

## Test plan
- [ ] Open `/Biblivre6/spa/search?showSelectSchema` and confirm **Voltar para a interface clássica** is an `<a>` that navigates to the classic UI
- [ ] With a library selected, the same button goes to `/{context}/{schema}`
- [ ] Bibliographic search and login still work (legacy JSON POSTs return JSON, not HTML)


Made with [Cursor](https://cursor.com)