### PR TITLE
ci: upgrade upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload packaged app
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: biblivre6-webapp
           path: target/Biblivre6
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download packaged app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: biblivre6-webapp
           path: target/Biblivre6


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` from v4 to v7 (current major; Node 24 runners).
- Bump `actions/download-artifact` from v4 to v8 so it matches upload-artifact v7.
- Inputs stay the same (`name`, `path`, `retention-days`); zip behavior is unchanged because `archive` still defaults to `true`.

## Test plan
- [x] Confirm CI on this PR uses the new action majors without workflow parse errors.
- [ ] After merge, confirm a push to `master` still uploads `biblivre6-webapp` and the docker job downloads it into `target/Biblivre6`.


Made with [Cursor](https://cursor.com)