### PR TITLE
Honor a proxy-bound schema so tenant hosts cannot see other libraries

### DIFF
--- a/docs/adr/0002-bound-schema-header-hides-other-libraries.md
+++ b/docs/adr/0002-bound-schema-header-hides-other-libraries.md
@@ -1,0 +1,17 @@
+# Bound schema header hides other libraries
+
+A public tenant host (nginx in front of one Biblivre instance) must not reveal or serve other libraries. We honor `X-Biblivre-Bound-Schema` from the proxy: list and JSP see only that schema, a path to another schema is 403, and a missing header keeps the current multi-schema picker for local/dev and the unpublished management host.
+
+## Considered Options
+
+- **Hide the SPA picker only** — the public `multi_schema.list` and `/other/` still leak
+- **Finish isolation in nginx** (`sub_filter` on JSON, prefix `/spa`) — breaks on the next endpoint
+- **Overwrite `X-Biblivre-Schema`** — the SPA already sends that header from `localStorage`, so a path to another schema would be forced instead of 403
+- **Bound header + 403 on path mismatch** (chosen) — nginx is the host→schema map; Biblivre enforces visibility and access at the request edge
+
+## Consequences
+
+- Nginx must set `X-Biblivre-Bound-Schema` on every public `location` (`/`, `/spa`, `/api/`, `/static/`, `/Biblivre6/`)
+- `/spa` is a reserved path, not a schema name
+- A stale client `X-Biblivre-Schema` is ignored when the bound header is present, so old `localStorage` does not 403 the API
+- `SchemaBO.getSchemas()` stays unfiltered (backup, index, migrations)

--- a/src/main/java/biblivre/core/controllers/CorsFilter.java
+++ b/src/main/java/biblivre/core/controllers/CorsFilter.java
@@ -75,7 +75,7 @@ public class CorsFilter implements Filter {
         } else {
             httpResponse.setHeader(
                     "Access-Control-Allow-Headers",
-                    "Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, X-Biblivre-Schema");
+                    "Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, X-Biblivre-Schema, X-Biblivre-Bound-Schema");
         }
         httpResponse.setHeader("Access-Control-Allow-Credentials", "true");
         httpResponse.setHeader("Access-Control-Max-Age", "3600");

--- a/src/main/java/biblivre/core/controllers/SchemaFilter.java
+++ b/src/main/java/biblivre/core/controllers/SchemaFilter.java
@@ -26,7 +26,9 @@ import biblivre.core.schemas.SchemaBO;
 import biblivre.core.utils.Constants;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class SchemaFilter implements Filter {
@@ -37,7 +39,20 @@ public class SchemaFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        String schema = SchemaUtil.extractSchema(request);
+        String boundSchema = SchemaUtil.extractBoundSchema(request);
+        String pathSchema = SchemaUtil.extractPathSchema(request);
+
+        if (StringUtils.isNotBlank(boundSchema)
+                && (schemaBO.isNotLoaded(boundSchema)
+                        || SchemaUtil.isForbiddenPathForBoundSchema(boundSchema, pathSchema))) {
+            ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+
+        String schema =
+                StringUtils.isNotBlank(boundSchema)
+                        ? boundSchema
+                        : SchemaUtil.extractSchema(request);
 
         if (schemaBO.isNotLoaded(schema)) {
             schema =
@@ -50,7 +65,8 @@ public class SchemaFilter implements Filter {
 
         HttpServletRequest httpRequest = (HttpServletRequest) request;
 
-        request.setAttribute("schemas", schemaBO.getSchemas());
+        request.setAttribute(
+                "schemas", SchemaUtil.visibleSchemas(boundSchema, schemaBO.getSchemas()));
 
         request.setAttribute("configurations", configurationBO);
 

--- a/src/main/java/biblivre/core/controllers/SchemaUtil.java
+++ b/src/main/java/biblivre/core/controllers/SchemaUtil.java
@@ -1,5 +1,6 @@
 package biblivre.core.controllers;
 
+import biblivre.core.schemas.SchemaDTO;
 import biblivre.core.utils.Constants;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,6 +8,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public class SchemaUtil {
@@ -14,37 +18,71 @@ public class SchemaUtil {
     public static final String SPA_STATIC_PATH = "/static/spa";
     public static final String SPA_SCHEMA_QUERY_PARAM = "schema";
     public static final String SPA_SHOW_SELECT_SCHEMA_QUERY_PARAM = "showSelectSchema";
+    public static final String BOUND_SCHEMA_HEADER = "X-Biblivre-Bound-Schema";
 
     private static final Collection<String> RESERVED_PATHS =
             Arrays.asList(
-                    "api", "DigitalMediaController", "static", "favicon.ico", "login", "logout");
+                    "api",
+                    "DigitalMediaController",
+                    "static",
+                    "favicon.ico",
+                    "login",
+                    "logout",
+                    "spa");
 
     public static String extractSchema(ServletRequest request) {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-
-        String requestURI = httpServletRequest.getRequestURI();
-
-        String contextPath = httpServletRequest.getContextPath();
-
-        String url = requestURI.substring(contextPath.length() + 1);
-
         String schema = getSchemaFromRequestHeaders(request);
 
         if (schema != null) {
             return schema;
         }
 
-        if (!url.isEmpty()) {
-            String[] urlArray = url.split("/");
+        return extractPathSchema(request);
+    }
 
-            if (urlArray.length == 0 || isReservedPath(urlArray[0])) {
-                return null;
-            }
+    public static String extractBoundSchema(ServletRequest request) {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String boundSchema = httpServletRequest.getHeader(BOUND_SCHEMA_HEADER);
+        return StringUtils.isBlank(boundSchema) ? null : boundSchema.trim();
+    }
 
-            return urlArray[0];
+    public static String extractPathSchema(ServletRequest request) {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        String requestURI = httpServletRequest.getRequestURI();
+        String contextPath = httpServletRequest.getContextPath();
+
+        if (requestURI.length() <= contextPath.length() + 1) {
+            return null;
         }
 
-        return null;
+        String url = requestURI.substring(contextPath.length() + 1);
+
+        if (url.isEmpty()) {
+            return null;
+        }
+
+        String[] urlArray = url.split("/");
+
+        if (urlArray.length == 0 || isReservedPath(urlArray[0])) {
+            return null;
+        }
+
+        return urlArray[0];
+    }
+
+    public static boolean isForbiddenPathForBoundSchema(String boundSchema, String pathSchema) {
+        return pathSchema != null && !pathSchema.equals(boundSchema);
+    }
+
+    public static Set<SchemaDTO> visibleSchemas(String boundSchema, Set<SchemaDTO> schemas) {
+        if (StringUtils.isBlank(boundSchema)) {
+            return schemas;
+        }
+
+        return schemas.stream()
+                .filter(schema -> boundSchema.equals(schema.getSchema()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static boolean isReservedPath(String s) {

--- a/src/main/java/biblivre/multi_schema/Handler.java
+++ b/src/main/java/biblivre/multi_schema/Handler.java
@@ -25,6 +25,7 @@ import biblivre.core.ExtendedRequest;
 import biblivre.core.ExtendedResponse;
 import biblivre.core.SchemaThreadLocal;
 import biblivre.core.configurations.ConfigurationBO;
+import biblivre.core.controllers.SchemaUtil;
 import biblivre.core.enums.ActionResult;
 import biblivre.core.schemas.SchemaBO;
 import biblivre.core.schemas.SchemaDTO;
@@ -128,7 +129,8 @@ public class Handler extends AbstractHandler {
     public void list(ExtendedRequest request, ExtendedResponse response) {
         try {
             JSONArray array = new JSONArray();
-            for (SchemaDTO dto : schemaBO.getSchemas()) {
+            String boundSchema = SchemaUtil.extractBoundSchema(request);
+            for (SchemaDTO dto : SchemaUtil.visibleSchemas(boundSchema, schemaBO.getSchemas())) {
                 if (dto.isDisabled()) {
                     continue;
                 }

--- a/src/test/java/biblivre/core/controllers/SchemaFilterTest.java
+++ b/src/test/java/biblivre/core/controllers/SchemaFilterTest.java
@@ -1,0 +1,114 @@
+package biblivre.core.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import biblivre.core.SchemaThreadLocal;
+import biblivre.core.configurations.ConfigurationBO;
+import biblivre.core.configurations.FlagsProvider;
+import biblivre.core.schemas.SchemaBO;
+import biblivre.core.schemas.SchemaDTO;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class SchemaFilterTest {
+
+    @AfterEach
+    void tearDown() {
+        SchemaThreadLocal.remove();
+    }
+
+    @Test
+    void rejectsPathToAnotherSchemaWhenBound() throws Exception {
+        SchemaFilter filter = boundFilter("temp", true);
+        MockHttpServletRequest request = requestAt("/Biblivre6/other/");
+        request.addHeader(SchemaUtil.BOUND_SCHEMA_HEADER, "temp");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+        verify(chain, never()).doFilter(any(), any());
+        assertNull(SchemaThreadLocal.get());
+    }
+
+    @Test
+    void rejectsUnknownBoundSchema() throws Exception {
+        SchemaFilter filter = boundFilter("ghost", false);
+        MockHttpServletRequest request = requestAt("/Biblivre6/spa/search");
+        request.addHeader(SchemaUtil.BOUND_SCHEMA_HEADER, "ghost");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void usesBoundSchemaOnReservedPathsAndIgnoresClientSchemaHeader() throws Exception {
+        SchemaDTO temp = new SchemaDTO("temp", "Temp");
+        SchemaDTO other = new SchemaDTO("other", "Other");
+        SchemaFilter filter = boundFilter("temp", true, Set.of(temp, other));
+        MockHttpServletRequest request = requestAt("/Biblivre6/spa/search");
+        request.addHeader(SchemaUtil.BOUND_SCHEMA_HEADER, "temp");
+        request.addHeader("X-Biblivre-Schema", "other");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(
+                request, response, (req, res) -> assertEquals("temp", SchemaThreadLocal.get()));
+
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals(Set.of(temp), request.getAttribute("schemas"));
+        assertEquals("/Biblivre6/spa/search?schema=temp", request.getAttribute("spaHref"));
+    }
+
+    @Test
+    void allowsPathThatMatchesBoundSchema() throws Exception {
+        SchemaDTO temp = new SchemaDTO("temp", "Temp");
+        SchemaFilter filter = boundFilter("temp", true, Set.of(temp));
+        MockHttpServletRequest request = requestAt("/Biblivre6/temp/");
+        request.addHeader(SchemaUtil.BOUND_SCHEMA_HEADER, "temp");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(
+                request, response, (req, res) -> assertEquals("temp", SchemaThreadLocal.get()));
+
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+    }
+
+    private static SchemaFilter boundFilter(String boundSchema, boolean loaded) {
+        return boundFilter(boundSchema, loaded, Set.of());
+    }
+
+    private static SchemaFilter boundFilter(
+            String boundSchema, boolean loaded, Set<SchemaDTO> schemas) {
+        SchemaFilter filter = new SchemaFilter();
+        SchemaBO schemaBO = mock(SchemaBO.class);
+        when(schemaBO.isNotLoaded(boundSchema)).thenReturn(!loaded);
+        when(schemaBO.getSchemas()).thenReturn(schemas);
+        filter.setSchemaBO(schemaBO);
+        filter.setConfigurationBO(mock(ConfigurationBO.class));
+        filter.setFlagsProvider(mock(FlagsProvider.class));
+        return filter;
+    }
+
+    private static MockHttpServletRequest requestAt(String requestURI) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("/Biblivre6");
+        request.setRequestURI(requestURI);
+        return request;
+    }
+}

--- a/src/test/java/biblivre/core/controllers/SchemaUtilTest.java
+++ b/src/test/java/biblivre/core/controllers/SchemaUtilTest.java
@@ -1,9 +1,15 @@
 package biblivre.core.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import biblivre.core.schemas.SchemaDTO;
 import biblivre.core.utils.Constants;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 class SchemaUtilTest {
 
@@ -46,5 +52,87 @@ class SchemaUtilTest {
         assertEquals("/biblivre/static/spa", SchemaUtil.buildSpaStaticBase("/biblivre"));
         assertEquals("/static/spa", SchemaUtil.buildSpaStaticBase(""));
         assertEquals("/static/spa", SchemaUtil.buildSpaStaticBase(null));
+    }
+
+    @Test
+    void extractBoundSchema_readsBoundHeader() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(SchemaUtil.BOUND_SCHEMA_HEADER, "temp");
+
+        assertEquals("temp", SchemaUtil.extractBoundSchema(request));
+    }
+
+    @Test
+    void extractBoundSchema_treatsBlankAsAbsent() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(SchemaUtil.BOUND_SCHEMA_HEADER, "  ");
+
+        assertNull(SchemaUtil.extractBoundSchema(request));
+    }
+
+    @Test
+    void extractPathSchema_readsFirstSegment() {
+        MockHttpServletRequest request = requestAt("/Biblivre6", "/Biblivre6/temp/cataloging");
+
+        assertEquals("temp", SchemaUtil.extractPathSchema(request));
+    }
+
+    @Test
+    void extractPathSchema_ignoresReservedSpaPath() {
+        MockHttpServletRequest request = requestAt("/Biblivre6", "/Biblivre6/spa/search");
+
+        assertNull(SchemaUtil.extractPathSchema(request));
+    }
+
+    @Test
+    void extractPathSchema_ignoresReservedApiPath() {
+        MockHttpServletRequest request = requestAt("/Biblivre6", "/Biblivre6/api/v2/users");
+
+        assertNull(SchemaUtil.extractPathSchema(request));
+    }
+
+    @Test
+    void extractSchema_stillPrefersClientSchemaHeaderWhenUnbound() {
+        MockHttpServletRequest request = requestAt("/Biblivre6", "/Biblivre6/temp/");
+        request.addHeader("X-Biblivre-Schema", "other");
+
+        assertEquals("other", SchemaUtil.extractSchema(request));
+    }
+
+    @Test
+    void extractSchema_doesNotTreatSpaAsALibrarySchema() {
+        MockHttpServletRequest request = requestAt("/Biblivre6", "/Biblivre6/spa/search");
+
+        assertNull(SchemaUtil.extractSchema(request));
+    }
+
+    @Test
+    void isForbiddenPathForBoundSchema_whenPathNamesAnotherSchema() {
+        assertTrue(SchemaUtil.isForbiddenPathForBoundSchema("temp", "other"));
+        assertFalse(SchemaUtil.isForbiddenPathForBoundSchema("temp", "temp"));
+        assertFalse(SchemaUtil.isForbiddenPathForBoundSchema("temp", null));
+    }
+
+    @Test
+    void visibleSchemas_whenBound_returnsOnlyThatSchema() {
+        SchemaDTO temp = new SchemaDTO("temp", "Temp");
+        SchemaDTO other = new SchemaDTO("other", "Other");
+
+        assertEquals(Set.of(temp), SchemaUtil.visibleSchemas("temp", Set.of(temp, other)));
+    }
+
+    @Test
+    void visibleSchemas_whenUnbound_returnsAll() {
+        SchemaDTO temp = new SchemaDTO("temp", "Temp");
+        SchemaDTO other = new SchemaDTO("other", "Other");
+
+        assertEquals(Set.of(temp, other), SchemaUtil.visibleSchemas(null, Set.of(temp, other)));
+    }
+
+    private static MockHttpServletRequest requestAt(String contextPath, String requestURI) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath(contextPath);
+        request.setRequestURI(requestURI);
+        return request;
     }
 }

--- a/src/test/java/biblivre/multi_schema/MultiSchemaListHandlerTest.java
+++ b/src/test/java/biblivre/multi_schema/MultiSchemaListHandlerTest.java
@@ -1,0 +1,80 @@
+package biblivre.multi_schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import biblivre.core.ExtendedRequest;
+import biblivre.core.ExtendedResponse;
+import biblivre.core.HandlerContext;
+import biblivre.core.HandlerContextThreadLocal;
+import biblivre.core.configurations.ConfigurationBO;
+import biblivre.core.controllers.SchemaUtil;
+import biblivre.core.schemas.SchemaBO;
+import biblivre.core.schemas.SchemaDTO;
+import biblivre.core.utils.Constants;
+import java.util.HashSet;
+import java.util.Set;
+import org.json.JSONArray;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MultiSchemaListHandlerTest {
+    private Handler handler;
+    private SchemaBO schemaBO;
+    private ConfigurationBO configurationBO;
+    private HandlerContext handlerContext;
+
+    @BeforeEach
+    void setUp() {
+        schemaBO = mock(SchemaBO.class);
+        configurationBO = mock(ConfigurationBO.class);
+        handler = new Handler();
+        handler.setSchemaBO(schemaBO);
+        handler.setConfigurationBO(configurationBO);
+
+        handlerContext = new HandlerContext();
+        HandlerContextThreadLocal.setHandlerContext(handlerContext);
+
+        when(configurationBO.getString(Constants.CONFIG_SUBTITLE)).thenReturn("");
+        when(schemaBO.getSchemas())
+                .thenReturn(
+                        Set.of(
+                                new SchemaDTO("temp", "Temp Library"),
+                                new SchemaDTO("other", "Other Library")));
+    }
+
+    @AfterEach
+    void tearDown() {
+        HandlerContextThreadLocal.remove();
+    }
+
+    @Test
+    void list_whenUnbound_returnsEveryEnabledLibrary() {
+        ExtendedRequest request = mock(ExtendedRequest.class);
+
+        handler.list(request, mock(ExtendedResponse.class));
+
+        assertEquals(Set.of("temp", "other"), listedSchemas());
+    }
+
+    @Test
+    void list_whenBound_returnsOnlyTheBoundLibrary() {
+        ExtendedRequest request = mock(ExtendedRequest.class);
+        when(request.getHeader(SchemaUtil.BOUND_SCHEMA_HEADER)).thenReturn("temp");
+
+        handler.list(request, mock(ExtendedResponse.class));
+
+        assertEquals(Set.of("temp"), listedSchemas());
+    }
+
+    private Set<String> listedSchemas() {
+        JSONArray data = handlerContext.getJson().getJSONArray("data");
+        Set<String> schemas = new HashSet<>();
+        for (int i = 0; i < data.length(); i++) {
+            schemas.add(data.getJSONObject(i).getString("schema"));
+        }
+        return schemas;
+    }
+}


### PR DESCRIPTION
## Summary
- Opt-in `X-Biblivre-Bound-Schema` from a reverse proxy hides every other library on that request: `multi_schema.list` and JSP see one schema, and a path to another library is 403.
- Missing or blank header keeps the current multi-schema picker, so self-hosted installs are unchanged.
- `/spa` is treated as a reserved path (not a schema name) so the SPA can run under a bound host.

## Test plan
- [ ] Without the header: several enabled schemas still appear in **Escolher biblioteca** and `/other/` still opens that library.
- [ ] Nginx sets `X-Biblivre-Bound-Schema` on `/`, `/spa`, `/api/`, `/static/`, and `/Biblivre6/`: the picker disappears and search stays on that schema.
- [ ] Bound host + path `/Biblivre6/other/` returns 403.
- [ ] Bound host + stale `X-Biblivre-Schema` from the browser still serves the bound schema (no 403 on `/spa` or `/api`).
- [ ] Unpublished management host (no header) can still list, create, and toggle libraries.


Made with [Cursor](https://cursor.com)