### PR TITLE
fix: drop library schemas without a bind parameter

### DIFF
--- a/src/main/java/biblivre/core/schemas/SchemasDAOImpl.java
+++ b/src/main/java/biblivre/core/schemas/SchemasDAOImpl.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.postgresql.PGConnection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -85,15 +84,13 @@ public class SchemasDAOImpl extends AbstractDAO implements SchemaDAO {
                     boolean success = pst.executeUpdate() > 0;
 
                     if (success) {
-                        PGConnection unwrap = con.unwrap(PGConnection.class);
+                        String dropSql = "DROP SCHEMA \"" + dto.getSchema() + "\" CASCADE;";
 
-                        String dropSql = "DROP SCHEMA ? CASCADE;";
+                        try (Statement dropStatement = con.createStatement()) {
+                            dropStatement.executeUpdate(dropSql);
+                        }
 
-                        PreparedStatement dropSt = con.prepareStatement(dropSql);
-
-                        dropSt.setString(1, dto.getSchema());
-
-                        dropSt.executeUpdate();
+                        schemas = null;
                     }
 
                     return success;

--- a/src/test/java/biblivre/core/schemas/SchemasDAOImplTest.java
+++ b/src/test/java/biblivre/core/schemas/SchemasDAOImplTest.java
@@ -1,0 +1,66 @@
+package biblivre.core.schemas;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import biblivre.AbstractContainerDatabaseTest;
+import biblivre.TestDatasourceConfiguration;
+import biblivre.core.SchemaThreadLocal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Testcontainers
+@Import({TestDatasourceConfiguration.class})
+@ActiveProfiles("test")
+class SchemasDAOImplTest extends AbstractContainerDatabaseTest {
+    @Autowired private SchemaDAO schemaDAO;
+    @Autowired private DataSource dataSource;
+
+    @Test
+    void deleteRemovesCatalogRowAndDropsPostgresSchema() {
+        String schemaName = "delete_probe";
+        String schemaTitle = "Delete Probe";
+
+        SchemaThreadLocal.withGlobalSchema(
+                () -> {
+                    try (Connection connection = dataSource.getConnection();
+                            Statement statement = connection.createStatement()) {
+                        statement.execute("CREATE SCHEMA \"" + schemaName + "\"");
+                        statement.execute(
+                                "INSERT INTO schemas (schema, name, disabled) VALUES ('"
+                                        + schemaName
+                                        + "', '"
+                                        + schemaTitle
+                                        + "', false)");
+                    }
+
+                    SchemaDTO schemaToDelete = new SchemaDTO(schemaName, schemaTitle);
+
+                    assertTrue(schemaDAO.delete(schemaToDelete));
+                    assertFalse(schemaDAO.exists(schemaName));
+
+                    try (Connection connection = dataSource.getConnection();
+                            PreparedStatement preparedStatement =
+                                    connection.prepareStatement(
+                                            "SELECT 1 FROM information_schema.schemata"
+                                                    + " WHERE schema_name = ?")) {
+                        preparedStatement.setString(1, schemaName);
+                        try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                            assertFalse(resultSet.next());
+                        }
+                    }
+
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- Deleting a library failed because `DROP SCHEMA ? CASCADE` is invalid PostgreSQL: identifiers cannot be bind parameters, so the driver sent `$1` and the parser rejected it at position 13.
- Interpolate the quoted schema name instead, matching `createSchema` and `RestoreService.dropSchema`.
- Add a Testcontainers regression test that creates a throwaway schema, deletes it, and asserts both the catalog row and the Postgres schema are gone.

## Test plan
- [x] `mvn test -Dtest=SchemasDAOImplTest -P developer`
- [x] In a multi-schema instance, create a disposable library and delete it from the admin UI
- [x] Confirm the library disappears from the picker and `DROP SCHEMA` no longer appears in the logs as a `$1` syntax error
- [x] Confirm remaining libraries still load


Made with [Cursor](https://cursor.com)