### PR TITLE
fix: prevent NPEs in SchemaServlet forward and extra/ wrap

### DIFF
--- a/src/main/java/biblivre/core/controllers/SchemaServlet.java
+++ b/src/main/java/biblivre/core/controllers/SchemaServlet.java
@@ -97,9 +97,7 @@ public class SchemaServlet extends HttpServlet {
         // starts with /api
         if (request.getServletPath().startsWith("/api")
                 || request.getServletPath().startsWith("/spa")) {
-            RequestDispatcher rd = this.getServletContext().getNamedDispatcher("dispatcherServlet");
-
-            rd.forward(request, response);
+            forwardToDispatcherServlet(request, response);
 
             return;
         }
@@ -280,8 +278,6 @@ public class SchemaServlet extends HttpServlet {
         }
 
         // Other static files
-        RequestDispatcher rd = this.getServletContext().getNamedDispatcher("dispatcherServlet");
-
         ExtendedRequest wrapped =
                 new ExtendedRequest(request, requestParserHelper, languageBO, translationBO) {
 
@@ -291,7 +287,20 @@ public class SchemaServlet extends HttpServlet {
                     }
                 };
 
-        rd.forward(wrapped, response);
+        forwardToDispatcherServlet(wrapped, response);
+    }
+
+    private void forwardToDispatcherServlet(
+            HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        RequestDispatcher requestDispatcher =
+                this.getServletContext().getNamedDispatcher("dispatcherServlet");
+
+        if (requestDispatcher == null) {
+            throw new ServletException("Named dispatcher 'dispatcherServlet' is not available");
+        }
+
+        requestDispatcher.forward(request, response);
     }
 
     private String servletContextAwareStaticPath(String path) {
@@ -344,5 +353,10 @@ public class SchemaServlet extends HttpServlet {
     @Autowired
     public void setConfigurationBO(ConfigurationBO configurationBO) {
         this.configurationBO = configurationBO;
+    }
+
+    @Autowired
+    public void setRequestParserHelper(RequestParserHelper requestParserHelper) {
+        this.requestParserHelper = requestParserHelper;
     }
 }

--- a/src/test/java/biblivre/core/controllers/SchemaServletTest.java
+++ b/src/test/java/biblivre/core/controllers/SchemaServletTest.java
@@ -1,0 +1,84 @@
+package biblivre.core.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import biblivre.core.RequestParserHelper;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+class SchemaServletTest {
+
+    @Test
+    void setRequestParserHelper_isAutowired() throws Exception {
+        Method setter =
+                SchemaServlet.class.getMethod("setRequestParserHelper", RequestParserHelper.class);
+
+        assertNotNull(
+                setter.getAnnotation(Autowired.class),
+                "RequestParserHelper must be Spring-injected so extra/ static files can wrap the request");
+    }
+
+    @Test
+    void service_forwardsApiRequestsToDispatcherServlet() throws Exception {
+        RecordingRequestDispatcher requestDispatcher = new RecordingRequestDispatcher();
+        SchemaServlet servlet = servletWithNamedDispatcher(requestDispatcher);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v2/schemas");
+        request.setServletPath("/api/v2/schemas");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        servlet.service(request, response);
+
+        assertSame(request, requestDispatcher.forwardedRequest);
+        assertSame(response, requestDispatcher.forwardedResponse);
+    }
+
+    @Test
+    void service_throwsWhenDispatcherServletIsMissing() throws Exception {
+        SchemaServlet servlet = new SchemaServlet();
+        servlet.init(new MockServletConfig(new MockServletContext()));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v2/schemas");
+        request.setServletPath("/api/v2/schemas");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ServletException exception =
+                assertThrows(ServletException.class, () -> servlet.service(request, response));
+
+        assertTrue(exception.getMessage().contains("dispatcherServlet"));
+    }
+
+    private static SchemaServlet servletWithNamedDispatcher(RequestDispatcher requestDispatcher)
+            throws Exception {
+        MockServletContext servletContext = new MockServletContext();
+        servletContext.registerNamedDispatcher("dispatcherServlet", requestDispatcher);
+
+        SchemaServlet servlet = new SchemaServlet();
+        servlet.init(new MockServletConfig(servletContext));
+        return servlet;
+    }
+
+    private static final class RecordingRequestDispatcher implements RequestDispatcher {
+        private ServletRequest forwardedRequest;
+        private ServletResponse forwardedResponse;
+
+        @Override
+        public void forward(ServletRequest request, ServletResponse response) {
+            this.forwardedRequest = request;
+            this.forwardedResponse = response;
+        }
+
+        @Override
+        public void include(ServletRequest request, ServletResponse response) {}
+    }
+}


### PR DESCRIPTION
## Summary
- Inject `RequestParserHelper` into `SchemaServlet` so wrapping `extra/` static requests no longer NPEs.
- Fail with a clear `ServletException` when the named `dispatcherServlet` is missing, instead of crashing on `forward`.

## Test plan
- [x] `mvn surefire:test -Dtest=SchemaServletTest -P developer`
- [ ] Open a `/api/...` route and confirm it still forwards to Spring MVC
- [ ] Request a file under `extra/` and confirm it loads (no NPE in logs)
- [ ] Request a `/spa` path and confirm the SPA still renders


Made with [Cursor](https://cursor.com)