### PR TITLE
fix: generate report ids on tables created by Hibernate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<spring-security.version>7.1.0</spring-security.version>
 		<opentelemetry.version>1.63.0</opentelemetry.version>
 		<openpdf.version>2.4.0</openpdf.version>
-		<logback.version>1.5.35</logback.version>
+		<logback.version>1.6.3</logback.version>
 		<jackson-2-bom.version>2.21.5</jackson-2-bom.version>
 		<jackson-bom.version>3.1.5</jackson-bom.version>
 		<log4j2.version>2.25.5</log4j2.version>

--- a/src/main/java/biblivre/update/v6_0_0$9_0_7$alpha/Update.java
+++ b/src/main/java/biblivre/update/v6_0_0$9_0_7$alpha/Update.java
@@ -1,0 +1,114 @@
+package biblivre.update.v6_0_0$9_0_7$alpha;
+
+import biblivre.update.UpdateService;
+import biblivre.update.exception.UpdateException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.springframework.stereotype.Component;
+
+/**
+ * Report tables created by Hibernate {@code ddl-auto=update} have {@code id bigint not null} with
+ * no sequence default. JDBC inserts omit {@code id} and then fail the not-null constraint. Attach a
+ * BIGSERIAL-compatible default on databases that still have the Hibernate shape.
+ */
+@Component
+public class Update implements UpdateService {
+
+    private static final String[] REPORT_TABLES = {"report", "report_parameters", "report_fill"};
+
+    @Override
+    public void doUpdate(Connection connection) {
+        try {
+            for (String table : REPORT_TABLES) {
+                ensureIdSerialDefault(connection, "global", table);
+            }
+        } catch (SQLException e) {
+            throw new UpdateException("Error attaching serial defaults to report tables", e);
+        }
+    }
+
+    static void ensureIdSerialDefault(Connection connection, String schema, String table)
+            throws SQLException {
+        validateIdentifier(schema);
+        validateIdentifier(table);
+
+        if (!tableExists(connection, schema, table)) {
+            return;
+        }
+
+        if (hasIdDefault(connection, schema, table)) {
+            return;
+        }
+
+        String qualifiedTable = schema + "." + table;
+        String qualifiedSequence = schema + "." + table + "_id_seq";
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE SEQUENCE IF NOT EXISTS " + qualifiedSequence);
+            statement.execute(
+                    "ALTER SEQUENCE " + qualifiedSequence + " OWNED BY " + qualifiedTable + ".id");
+            statement.execute(
+                    "ALTER TABLE "
+                            + qualifiedTable
+                            + " ALTER COLUMN id SET DEFAULT nextval('"
+                            + qualifiedSequence
+                            + "')");
+            try (ResultSet ignored =
+                    statement.executeQuery(
+                            "SELECT setval('"
+                                    + qualifiedSequence
+                                    + "', COALESCE((SELECT MAX(id) FROM "
+                                    + qualifiedTable
+                                    + "), 0) + 1, false)")) {
+                // setval is invoked by executing the query
+            }
+        }
+    }
+
+    private static boolean tableExists(Connection connection, String schema, String table)
+            throws SQLException {
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        """
+                        SELECT 1
+                        FROM information_schema.tables
+                        WHERE table_schema = ? AND table_name = ?
+                        """)) {
+            statement.setString(1, schema);
+            statement.setString(2, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private static boolean hasIdDefault(Connection connection, String schema, String table)
+            throws SQLException {
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        """
+                        SELECT column_default
+                        FROM information_schema.columns
+                        WHERE table_schema = ? AND table_name = ? AND column_name = 'id'
+                        """)) {
+            statement.setString(1, schema);
+            statement.setString(2, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return true;
+                }
+                String columnDefault = resultSet.getString(1);
+                return columnDefault != null && !columnDefault.isBlank();
+            }
+        }
+    }
+
+    private static void validateIdentifier(String identifier) {
+        if (identifier == null || !identifier.matches("[a-z][a-z0-9_]*")) {
+            throw new IllegalArgumentException("Invalid SQL identifier: " + identifier);
+        }
+    }
+}

--- a/src/test/java/biblivre/update/v6_0_0$9_0_7$alpha/UpdateTest.java
+++ b/src/test/java/biblivre/update/v6_0_0$9_0_7$alpha/UpdateTest.java
@@ -1,0 +1,93 @@
+package biblivre.update.v6_0_0$9_0_7$alpha;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import biblivre.AbstractContainerDatabaseTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PSQLException;
+
+class UpdateTest extends AbstractContainerDatabaseTest {
+
+    private static final String PROBE_SCHEMA = "hibernate_report_upgrade";
+
+    @Test
+    void attachesSerialDefaultToHibernateStyleReportId() throws Exception {
+        try (Connection connection = openConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP SCHEMA IF EXISTS " + PROBE_SCHEMA + " CASCADE");
+            statement.execute("CREATE SCHEMA " + PROBE_SCHEMA);
+            // Column order matches Hibernate 6 ddl-auto=update for Report.
+            statement.execute(
+                    """
+                    CREATE TABLE hibernate_report_upgrade.report (
+                        id BIGINT NOT NULL,
+                        description VARCHAR(255),
+                        digital_media_id BIGINT NOT NULL,
+                        name VARCHAR(255),
+                        schema VARCHAR(255),
+                        PRIMARY KEY (id)
+                    )
+                    """);
+
+            try {
+                insertSampleReport(statement);
+                fail("Insert without id should fail on a Hibernate-created report table");
+            } catch (PSQLException exception) {
+                assertTrue(
+                        exception
+                                .getMessage()
+                                .contains("null value in column \"id\" of relation \"report\""));
+                assertTrue(
+                        exception
+                                .getMessage()
+                                .contains("Failing row contains (null, 01, 2, teste, single)."));
+            }
+
+            Update.ensureIdSerialDefault(connection, PROBE_SCHEMA, "report");
+
+            insertSampleReport(statement);
+
+            try (ResultSet resultSet =
+                    statement.executeQuery(
+                            "SELECT id, name, description, schema, digital_media_id"
+                                    + " FROM hibernate_report_upgrade.report")) {
+                assertTrue(resultSet.next());
+                assertEquals(1L, resultSet.getLong("id"));
+                assertEquals("teste", resultSet.getString("name"));
+                assertEquals("01", resultSet.getString("description"));
+                assertEquals("single", resultSet.getString("schema"));
+                assertEquals(2L, resultSet.getLong("digital_media_id"));
+            }
+
+            Update.ensureIdSerialDefault(connection, PROBE_SCHEMA, "report");
+        } finally {
+            try (Connection connection = openConnection();
+                    Statement statement = connection.createStatement()) {
+                statement.execute("DROP SCHEMA IF EXISTS " + PROBE_SCHEMA + " CASCADE");
+            }
+        }
+    }
+
+    private static void insertSampleReport(Statement statement) throws SQLException {
+        statement.executeUpdate(
+                """
+                INSERT INTO hibernate_report_upgrade.report
+                    (name, description, schema, digital_media_id)
+                VALUES ('teste', '01', 'single', 2)
+                """);
+    }
+
+    private static Connection openConnection() throws SQLException {
+        return DriverManager.getConnection(
+                postgreSQLContainer.getJdbcUrl(),
+                postgreSQLContainer.getUsername(),
+                postgreSQLContainer.getPassword());
+    }
+}


### PR DESCRIPTION
## Summary
- Compiling a custom report template inserts into `global.report` without `id`. That works on BIGSERIAL tables, but databases that still have the Hibernate `ddl-auto=update` shape (`id bigint not null`, no sequence default) fail with `null value in column "id"`.
- Add update `v6_0_0$9_0_7$alpha` to attach a serial default on `global.report`, `global.report_parameters`, and `global.report_fill` when it is missing. Existing BIGSERIAL installs are left unchanged.
- Bump Logback 1.5.35 → 1.6.3 so the pre-commit OSS Index audit passes (`CVE-2026-19880`). 1.6.x is a drop-in for 1.5.x; this project does not use `SiftingAppender` or Janino conditionals.

## Test plan
- [ ] Upload a JRXML template on an instance whose `global.report` was created by Hibernate and confirm the template is saved.
- [ ] Confirm a fresh install (BIGSERIAL `global.report`) still compiles and lists report templates.
- [x] `mvn test -Dtest='biblivre.update.v6_0_0$9_0_7$alpha.UpdateTest' -P developer` reproduces the production `Failing row contains (null, 01, 2, teste, single)` error on the Hibernate-shaped table, then succeeds after the update.


Made with [Cursor](https://cursor.com)