### PR TITLE
fix(deps): upgrade Spring Boot 4.1.1 and Jackson to clear ossindex CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.1.0</version>
+		<version>4.1.1</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -41,12 +41,12 @@
 		<webapp.dir>${basedir}/src/main/webapp</webapp.dir>
 		<error-prone.version>2.50.0</error-prone.version>
 		<maven.compiler.release>25</maven.compiler.release>
-		<spring-security.version>7.1.0</spring-security.version>
+		<spring-security.version>7.1.1</spring-security.version>
 		<opentelemetry.version>1.63.0</opentelemetry.version>
 		<openpdf.version>2.4.0</openpdf.version>
 		<logback.version>1.6.3</logback.version>
-		<jackson-2-bom.version>2.21.5</jackson-2-bom.version>
-		<jackson-bom.version>3.1.5</jackson-bom.version>
+		<jackson-2-bom.version>2.21.6</jackson-2-bom.version>
+		<jackson-bom.version>3.1.6</jackson-bom.version>
 		<log4j2.version>2.25.5</log4j2.version>
 		<skip.yarn>false</skip.yarn>
 	</properties>
@@ -449,12 +449,6 @@
 						<!-- Sonatype false positive: deprecated SubjectDnX509PrincipalExtractor still in jar -->
 						<excludeVulnerabilityId>CVE-2026-47838</excludeVulnerabilityId>
 						<!-- Sonatype false positive for 7.x; fixed in SubjectX500PrincipalExtractor since 7.0.5 -->
-						<!-- jackson-databind Path scheme restriction; patches merged but unreleased (2.21.6/2.22.2, 3.1.6/3.2.2) -->
-						<excludeVulnerabilityId>CVE-2026-19032</excludeVulnerabilityId>
-						<!-- jackson-databind GregorianCalendar/Duration number limits; same pending releases as CVE-2026-19032 -->
-						<excludeVulnerabilityId>CVE-2026-68497</excludeVulnerabilityId>
-						<!-- httpclient5 missing resource release after lifetime; reported against 5.6.1 -->
-						<excludeVulnerabilityId>CVE-2026-64607</excludeVulnerabilityId>
 					</excludeVulnerabilityIds>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## Summary
- Bump Spring Boot to 4.1.1 (Framework 7.0.9, Security 7.1.1, HttpClient5 5.6.4) and Jackson 2/3 BOMs to 2.21.6 / 3.1.6 so ossindex findings have real patches.
- Drop the now-fixed ossindex exclusions (`CVE-2026-19032`, `CVE-2026-68497`, `CVE-2026-64607`).
- Keep JasperReports and Spring Security false-positive exclusions that still have no community fix.

## Test plan
- [ ] `mvn -B -ntp org.sonatype.ossindex.maven:ossindex-maven-plugin:3.2.0:audit` passes
- [ ] CI `package` + smoke start succeed on this branch
- [ ] App still boots with the developer profile (RestClient / Security wiring unchanged)


Made with [Cursor](https://cursor.com)