### PR TITLE
fix: ignore psql restrict commands when restoring backups

### DIFF
--- a/src/main/java/biblivre/administration/backup/RestoreService.java
+++ b/src/main/java/biblivre/administration/backup/RestoreService.java
@@ -82,17 +82,20 @@ public class RestoreService {
                     new PostgreSQLStatementIterable(sourceIterator);
 
             for (String statement : postgreSQLStatementIterable) {
-                if (isFunctionOrTriggerRelated(statement)) {
+                String executableStatement = stripPsqlMetaCommands(statement);
+
+                if (executableStatement.isBlank()
+                        || isFunctionOrTriggerRelated(executableStatement)) {
                     continue;
                 }
 
-                if (statement.startsWith("COPY ")) {
-                    executePostgresCopyCommand(statement, sourceIterator);
+                if (executableStatement.startsWith("COPY ")) {
+                    executePostgresCopyCommand(executableStatement, sourceIterator);
 
                     continue;
                 }
 
-                writeLine(statement);
+                writeLine(executableStatement);
             }
         } catch (IOException e) {
             throw new RestoreException(e);
@@ -101,6 +104,22 @@ public class RestoreService {
 
     public static boolean isFunctionOrTriggerRelated(String statement) {
         return Arrays.stream(FILTERED_OUT_STATEMENT_PREFIXES).anyMatch(statement::startsWith);
+    }
+
+    static String stripPsqlMetaCommands(String statement) {
+        String remaining = statement;
+
+        while (remaining.startsWith("\\")) {
+            String stripped = remaining.replaceFirst("^\\\\[A-Za-z.]+(?:\\s+\\S+)?\\s*", "");
+
+            if (stripped.equals(remaining)) {
+                return "";
+            }
+
+            remaining = stripped;
+        }
+
+        return remaining;
     }
 
     private void executePostgresCopyCommand(String copyCommand, Iterator<Character> sourceIterator)
@@ -337,13 +356,19 @@ public class RestoreService {
             Map<Long, Long> oidMap = new HashMap<>();
 
             for (String statement : postgreSQLStatementIterable) {
-                if (statement.startsWith("COPY ")) {
-                    executePostgresCopyCommand(statement, sourceIterator);
+                String executableStatement = stripPsqlMetaCommands(statement);
+
+                if (executableStatement.isBlank()) {
+                    continue;
+                }
+
+                if (executableStatement.startsWith("COPY ")) {
+                    executePostgresCopyCommand(executableStatement, sourceIterator);
 
                     continue;
                 }
 
-                processLOLine(statement, oidMap, sourceIterator);
+                processLOLine(executableStatement, oidMap, sourceIterator);
             }
 
             setPGSearchPath(schema);

--- a/src/test/java/biblivre/administration/backup/RestoreServiceTest.java
+++ b/src/test/java/biblivre/administration/backup/RestoreServiceTest.java
@@ -3,8 +3,10 @@ package biblivre.administration.backup;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +34,44 @@ class RestoreServiceTest {
         assertNotNull(
                 setter.getAnnotation(Autowired.class),
                 "DigitalMediaDAO must be Spring-injected for media restore during backup restore");
+    }
+
+    @Test
+    void processRestore_skipsPsqlRestrictMetaCommandsAndExecutesFollowingSql() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+
+        RestoreService service = new RestoreService();
+        service.setDataSource(dataSource);
+
+        Path dump = tempDir.resolve("global.schema.b5b");
+        Files.writeString(
+                dump,
+                """
+                -- PostgreSQL database dump
+                --
+
+                \\restrict Dpg1CK9sasGyNv4DJoJAVOrQ7NnPCsVnFuYfKOlq9UVNnBQ9DWnYhnnxt8dbmhg
+
+                SET statement_timeout = 0;
+
+                --
+                -- PostgreSQL database dump complete
+                --
+
+                \\unrestrict Dpg1CK9sasGyNv4DJoJAVOrQ7NnPCsVnFuYfKOlq9UVNnBQ9DWnYhnnxt8dbmhg
+                """);
+
+        State.start();
+
+        service.processRestore(dump.toFile());
+
+        verify(statement).execute("SET statement_timeout = 0;");
+        verify(statement, never()).execute(argThat(sql -> sql.startsWith("\\")));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `pg_dump` 16.14+ prefixes dumps with `\restrict` / `\unrestrict`, which JDBC cannot execute and aborted restore with `syntax error at or near "\"`.
- Restore now strips those psql meta-commands and still runs the SQL that was glued to them.

## Test plan
- [x] `mvn test -P developer -Dtest=RestoreServiceTest`
- [ ] Restore a `.b5bz` produced by `pg_dump` 16.14+ (contains `\restrict` in `global.schema.b5b`)
- [ ] Confirm restore completes past "Processing schema for 'global'"
- [ ] Confirm a dump without `\restrict` still restores


Made with [Cursor](https://cursor.com)