### PR TITLE
Send bound-host classic navigation to the tenant root

### DIFF
--- a/src/main/java/biblivre/multi_schema/Handler.java
+++ b/src/main/java/biblivre/multi_schema/Handler.java
@@ -150,6 +150,7 @@ public class Handler extends AbstractHandler {
                 array.put(o);
             }
             put("data", array);
+            put("bound", StringUtils.isNotBlank(boundSchema));
             setMessage(ActionResult.SUCCESS);
         } catch (JSONException e) {
             setMessage(ActionResult.WARNING, ERROR_INVALID_JSON);

--- a/src/main/spa-frontend/src/AppHeader.tsx
+++ b/src/main/spa-frontend/src/AppHeader.tsx
@@ -49,7 +49,9 @@ const AppHeader: FC<Props> = ({ isDarkMode, setIsDarkMode }) => {
 
   const { data: session, isPending: isSessionPending } = useAuthSession()
   const { mutate: logout, isPending: isLogoutPending } = useLegacyLogout()
-  const { data: schemas, isPending: isSchemasPending } = useSchemasList()
+  const { data: schemasList, isPending: isSchemasPending } = useSchemasList()
+  const schemas = schemasList?.schemas
+  const isBoundSchema = schemasList?.bound ?? false
 
   const [isSchemaModalOpen, setIsSchemaModalOpen] = useState(false)
 
@@ -80,6 +82,7 @@ const AppHeader: FC<Props> = ({ isDarkMode, setIsDarkMode }) => {
                 schemas,
                 activeSchemaId,
                 BIBLIVRE_ENDPOINT,
+                isBoundSchema,
               )}
             >
               <EuiFlexGroup alignItems='center' gutterSize='s'>

--- a/src/main/spa-frontend/src/api-helpers/schema/hooks.ts
+++ b/src/main/spa-frontend/src/api-helpers/schema/hooks.ts
@@ -8,6 +8,9 @@ export function useSchemasList() {
   return useQuery({
     queryKey: SCHEMAS_LIST_QUERY_KEY,
     queryFn: fetchSchemasList,
-    select: (data) => data.data,
+    select: (response) => ({
+      schemas: response.data,
+      bound: Boolean(response.bound),
+    }),
   })
 }

--- a/src/main/spa-frontend/src/api-helpers/types.ts
+++ b/src/main/spa-frontend/src/api-helpers/types.ts
@@ -35,6 +35,7 @@ export type SchemaListItem = {
 
 export type SchemasListResponse = SuccessfulResponse & {
   data: SchemaListItem[]
+  bound?: boolean
 }
 
 /** Session probe from `login.session`; extends the usual JSON success payload. */

--- a/src/main/spa-frontend/src/getLegacyLibraryUrl.test.ts
+++ b/src/main/spa-frontend/src/getLegacyLibraryUrl.test.ts
@@ -51,4 +51,18 @@ describe('getLegacyLibraryUrl', () => {
       getLegacyLibraryUrl([singleSchema, publicSchema], 'public', endpoint),
     ).toBe(`${endpoint}/public`)
   })
+
+  it('uses the classic root when the host is bound to a schema', () => {
+    expect(getLegacyLibraryUrl([singleSchema], 'single', endpoint, true)).toBe(
+      `${endpoint}/`,
+    )
+    expect(
+      getLegacyLibraryUrl(
+        [singleSchema, publicSchema],
+        'public',
+        endpoint,
+        true,
+      ),
+    ).toBe(`${endpoint}/`)
+  })
 })

--- a/src/main/spa-frontend/src/getLegacyLibraryUrl.ts
+++ b/src/main/spa-frontend/src/getLegacyLibraryUrl.ts
@@ -8,10 +8,11 @@ export function getLegacyLibraryUrl(
   schemas: SchemaListItem[] | undefined,
   activeSchemaId: string | null,
   endpoint: string,
+  isBoundSchema = false,
 ): string {
   const rootUrl = getLegacyRootUrl(endpoint)
 
-  if (!schemas || !activeSchemaId) {
+  if (isBoundSchema || !schemas || !activeSchemaId) {
     return rootUrl
   }
 

--- a/src/test/java/biblivre/multi_schema/MultiSchemaListHandlerTest.java
+++ b/src/test/java/biblivre/multi_schema/MultiSchemaListHandlerTest.java
@@ -1,6 +1,8 @@
 package biblivre.multi_schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,6 +59,7 @@ class MultiSchemaListHandlerTest {
         handler.list(request, mock(ExtendedResponse.class));
 
         assertEquals(Set.of("temp", "other"), listedSchemas());
+        assertFalse(handlerContext.getJson().getBoolean("bound"));
     }
 
     @Test
@@ -67,6 +70,7 @@ class MultiSchemaListHandlerTest {
         handler.list(request, mock(ExtendedResponse.class));
 
         assertEquals(Set.of("temp"), listedSchemas());
+        assertTrue(handlerContext.getJson().getBoolean("bound"));
     }
 
     private Set<String> listedSchemas() {


### PR DESCRIPTION
## Summary
- On a proxy-bound tenant host (`X-Biblivre-Bound-Schema`), **Voltar para a interface clássica** now goes to the host root instead of `/{schema}/`.
- `multi_schema.list` exposes `bound` so the SPA can tell a public tenant host from the unbound multi-library picker.
- Unbound installs keep the existing `/{schema}` classic path.

## Test plan
- [x] On `https://<tenant>.biblivre.cloud/spa/search/intelligent`, **Voltar para a interface clássica** opens `https://<tenant>.biblivre.cloud/` (not `/<tenant>/`).
- [x] Unbound / management host with several libraries still opens `/{schema}/` for the selected library.
- [x] Bound host still hides **Escolher biblioteca** and `multi_schema.list` returns only the bound schema with `bound: true`.


Made with [Cursor](https://cursor.com)