### PR TITLE
fix: strip JDT stub class files before compile so make dev can start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
 # Variables
 MAVEN_OPTS := -XX:+UnlockExperimentalVMOptions --enable-preview
 DEBUG_OPTS := -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-# spring-boot:run does not need tests; skip testCompile so JDT stub .class files
-# cannot fail the run (see maven-compiler-plugin useIncrementalCompilation).
+# spring-boot:run does not need tests. Skip testCompile (JDT stubs in
+# target/test-classes). Main stubs are stripped in process-resources
+# (see maven-antrun-plugin delete-jdt-stubs).
 SPRING_BOOT_RUN_ARGS := -Dmaven.test.skip=true
 DOCKER_COMPOSE_FILE := docker-compose.yml
 E2E_COMPOSE_FILE := $(CURDIR)/docker-compose.e2e.yml

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,15 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>recompile-after-jdt-stub-cleanup</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
 					<source>${jdk.version}</source>
 					<target>${jdk.version}</target>
@@ -614,6 +623,45 @@
 					</dependency>
 				</dependencies>
 				<executions>
+					<execution>
+						<id>delete-jdt-stubs</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<!-- Cursor/JDT writes "proceed with errors" stubs into
+									target/classes (default-package descriptors). Maven then
+									skips those sources because the stub .class is newer. -->
+								<delete verbose="true">
+									<fileset dir="${project.build.outputDirectory}"
+											erroronmissingdir="false">
+										<include name="**/*.class"/>
+										<contains text="Unresolved compilation"/>
+									</fileset>
+								</delete>
+							</target>
+						</configuration>
+					</execution>
+					<execution>
+						<id>delete-jdt-stubs-after-compile</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<delete verbose="true">
+									<fileset dir="${project.build.outputDirectory}"
+											erroronmissingdir="false">
+										<include name="**/*.class"/>
+										<contains text="Unresolved compilation"/>
+									</fileset>
+								</delete>
+							</target>
+						</configuration>
+					</execution>
 					<execution>
 						<id>update-spa-template</id>
 						<phase>generate-resources</phase>


### PR DESCRIPTION
## Summary
- Cursor/JDT writes “Unresolved compilation” stub `.class` files into `target/classes` during Yarn (after `mvn clean` and before `javac`). Maven then treats those stubs as up to date and `spring-boot:run` loads them — `ClassNotFoundException: IndexingGroupDTO` (default package).
- Delete any class file whose constant pool contains `Unresolved compilation` in `process-resources` and again in `process-classes`, then recompile so `make dev` starts with real bytecode.

## Test plan
- [ ] `mvn clean` then `make dev` starts the Spring context (no `BeanCreationException` on `IndexingGroupApiDelegateImpl`)
- [ ] Plant a stub (`Unresolved compilation` in a `*ApiDelegateImpl.class`) and run `mvn compile -Dskip.yarn=true -Dmaven.test.skip=true`; the stub is gone and `javap` shows the fully qualified `IndexingGroupDTO` parameter
- [x] `mvn test -P developer` still compiles (existing `useIncrementalCompilation=false` workaround)


Made with [Cursor](https://cursor.com)