### PR TITLE
fix: revert temporary schema names when backup restore fails

### DIFF
--- a/src/main/java/biblivre/administration/backup/RestoreBO.java
+++ b/src/main/java/biblivre/administration/backup/RestoreBO.java
@@ -37,6 +37,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -173,39 +174,98 @@ public class RestoreBO {
 
         State.writeLog("Starting psql");
 
-        restoreService.processSchemaRenames(context.getPreRenameSchemas());
+        boolean dataRestoreCompleted = false;
 
-        String extension = getExtension(dto);
+        try {
+            restoreService.processSchemaRenames(context.getPreRenameSchemas());
 
-        if (restoreSchemas.containsKey(globalSchema)) {
-            processGlobalSchema(explodedBackupDirectory, extension);
-        }
+            String extension = getExtension(dto);
 
-        for (String schema : restoreSchemas.keySet()) {
-            if (globalSchema.equals(schema)) {
-                continue;
+            if (restoreSchemas.containsKey(globalSchema)) {
+                processGlobalSchema(explodedBackupDirectory, extension);
             }
 
-            withSchema(
-                    schema,
-                    () ->
-                            restoreService.processSchemaRestores(
-                                    explodedBackupDirectory, extension, schema));
+            for (String schema : restoreSchemas.keySet()) {
+                if (globalSchema.equals(schema)) {
+                    continue;
+                }
+
+                withSchema(
+                        schema,
+                        () ->
+                                restoreService.processSchemaRestores(
+                                        explodedBackupDirectory, extension, schema));
+            }
+
+            dataRestoreCompleted = true;
+
+            restoreService.processSchemaRenames(context.getPostRenameSchemas());
+
+            restoreService.processSchemaRenames(context.getRestoreRenamedSchemas());
+
+            postProcessDeletes(context.getDeleteSchemas());
+
+            postProcessRenames(dto, restoreSchemas);
+
+            restoreService.removeNonExistingPGSchemaFromSchemasTable();
+        } catch (Exception exception) {
+            if (!dataRestoreCompleted) {
+                revertTemporarySchemaNames(context, restoreSchemas, exception);
+            }
+
+            throw toRestoreException(exception);
         }
-
-        restoreService.processSchemaRenames(context.getPostRenameSchemas());
-
-        restoreService.processSchemaRenames(context.getRestoreRenamedSchemas());
-
-        postProcessDeletes(context.getDeleteSchemas());
-
-        postProcessRenames(dto, restoreSchemas);
-
-        restoreService.removeNonExistingPGSchemaFromSchemasTable();
 
         logger.info("===== Restoring backup finished =====");
 
         return true;
+    }
+
+    private void revertTemporarySchemaNames(
+            RestoreContextHelper context,
+            Map<String, String> restoreSchemas,
+            Exception restoreFailure) {
+        try {
+            State.writeLog("Restore failed; reverting temporary schema names");
+
+            for (String sourceSchemaName : restoreSchemas.keySet()) {
+                try {
+                    restoreService.dropSchemaIfExists(sourceSchemaName);
+                } catch (Exception dropException) {
+                    logger.error(
+                            "Failed to drop partial schema {} after restore failure",
+                            sourceSchemaName,
+                            dropException);
+                    restoreFailure.addSuppressed(dropException);
+                }
+            }
+
+            Map<String, String> reverseRenames = new LinkedHashMap<>();
+
+            context.getPreRenameSchemas()
+                    .forEach(
+                            (originalSchemaName, temporarySchemaName) ->
+                                    reverseRenames.put(temporarySchemaName, originalSchemaName));
+
+            restoreService.processSchemaRenames(reverseRenames);
+        } catch (Exception rollbackException) {
+            logger.error(
+                    "Failed to revert temporary schema names after restore failure",
+                    rollbackException);
+            restoreFailure.addSuppressed(rollbackException);
+        }
+    }
+
+    private static RestoreException toRestoreException(Exception exception) {
+        if (exception instanceof RestoreException restoreException) {
+            return restoreException;
+        }
+
+        if (exception.getCause() instanceof RestoreException restoreException) {
+            return restoreException;
+        }
+
+        return new RestoreException(exception);
     }
 
     private void processGlobalSchema(File directory, String extension) throws RestoreException {

--- a/src/main/java/biblivre/administration/backup/RestoreService.java
+++ b/src/main/java/biblivre/administration/backup/RestoreService.java
@@ -228,6 +228,14 @@ public class RestoreService {
                         .formatted(schemaToBeDeleted));
     }
 
+    public void dropSchemaIfExists(String schemaToBeDeleted) throws RestoreException {
+        writeLine(
+                """
+                        DROP SCHEMA IF EXISTS "%s" CASCADE
+                        """
+                        .formatted(schemaToBeDeleted));
+    }
+
     public void deleteAllDigitalMedia(String schemaToBeDeleted) throws RestoreException {
         writeLine(
                 """

--- a/src/test/java/biblivre/administration/backup/RestoreBOTest.java
+++ b/src/test/java/biblivre/administration/backup/RestoreBOTest.java
@@ -1,0 +1,111 @@
+package biblivre.administration.backup;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import biblivre.administration.backup.exception.RestoreException;
+import biblivre.administration.setup.State;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RestoreBOTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void restore_whenSchemaRestoreFailsAfterPreRename_restoresOriginalSchemaNames()
+            throws Exception {
+        File backup = createMinimalBackupZip();
+
+        RestoreOperation restoreOperation = new RestoreOperation();
+        restoreOperation.setValid(true);
+        restoreOperation.setBackup(backup);
+        restoreOperation.setSchemas(Map.of("single", Pair.of("Library", "Subtitle")));
+        restoreOperation.setRestoreSchemas(Map.of("single", "single"));
+
+        RecordingRestoreService restoreService = new RecordingRestoreService();
+
+        RestoreBO restoreBO = new RestoreBO();
+        restoreBO.setBackupBO(new StubBackupBO());
+        restoreBO.setRestoreService(restoreService);
+
+        State.start();
+
+        assertThrows(Exception.class, () -> restoreBO.restore(restoreOperation, null));
+
+        assertTrue(
+                restoreService.droppedSchemas.contains("single"),
+                "Failed restore must drop the partial schema before renaming the original back");
+        assertTrue(
+                restoreService.schemaRenames.stream()
+                        .anyMatch(RestoreBOTest::renamesTemporarySchemasBackToOriginal),
+                "Failed restore left PostgreSQL schemas under temporary names (_schema_timestamp)");
+    }
+
+    private static boolean renamesTemporarySchemasBackToOriginal(Map<String, String> rename) {
+        return rename.entrySet().stream()
+                .anyMatch(
+                        entry ->
+                                entry.getKey().matches("_single_\\d+")
+                                        && "single".equals(entry.getValue()));
+    }
+
+    private File createMinimalBackupZip() throws Exception {
+        File backup = tempDir.resolve("restore-failure.b5bz").toFile();
+
+        try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(backup))) {
+            zip.putNextEntry(new ZipEntry("single.schema.b5b"));
+            zip.write("-- schema\n".getBytes());
+            zip.closeEntry();
+
+            zip.putNextEntry(new ZipEntry("single.data.b5b"));
+            zip.write("-- data\n".getBytes());
+            zip.closeEntry();
+
+            zip.putNextEntry(new ZipEntry("single.media.b5b"));
+            zip.write("-- media\n".getBytes());
+            zip.closeEntry();
+        }
+
+        return backup;
+    }
+
+    private static final class StubBackupBO extends BackupBO {
+        @Override
+        public Set<String> listDatabaseSchemas() {
+            return Set.of("global", "single");
+        }
+    }
+
+    private static final class RecordingRestoreService extends RestoreService {
+        private final List<Map<String, String>> schemaRenames = new ArrayList<>();
+        private final List<String> droppedSchemas = new ArrayList<>();
+
+        @Override
+        public void processSchemaRenames(Map<String, String> preRenameSchemas) {
+            schemaRenames.add(new HashMap<>(preRenameSchemas));
+        }
+
+        @Override
+        public void dropSchemaIfExists(String schemaToBeDeleted) {
+            droppedSchemas.add(schemaToBeDeleted);
+        }
+
+        @Override
+        public void processSchemaRestores(File path, String extension, String schema)
+                throws RestoreException {
+            throw new RestoreException("simulated restore failure");
+        }
+    }
+}

--- a/src/test/java/biblivre/administration/backup/RestoreServiceTest.java
+++ b/src/test/java/biblivre/administration/backup/RestoreServiceTest.java
@@ -100,4 +100,21 @@ class RestoreServiceTest {
         verify(statement)
                 .execute(contains("UPDATE digital_media SET blob = '42' WHERE id = '123'"));
     }
+
+    @Test
+    void dropSchemaIfExists_executesConditionalDrop() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+
+        RestoreService service = new RestoreService();
+        service.setDataSource(dataSource);
+
+        service.dropSchemaIfExists("single");
+
+        verify(statement).execute(contains("DROP SCHEMA IF EXISTS \"single\" CASCADE"));
+    }
 }


### PR DESCRIPTION
## Summary
- A failed backup restore left PostgreSQL schemas under `_schema_timestamp` names while `global.schemas` still pointed at the originals, which took the library down.
- Restore now drops any partial schema from the dump and renames the temporary schemas back when the data restore fails.
- Adds a regression test that fails if a mid-restore error leaves temporary names in place.

## Test plan
- [x] `mvn test -P developer -Dtest=RestoreBOTest`
- [ ] Restore a backup over an existing library (`single` → `single`) and confirm it still succeeds.
- [ ] Interrupt or force a failure during restore (invalid dump / mid-restore error) and confirm the original schema name is back and the library still opens.
- [ ] Confirm `global.schemas` still matches the live PostgreSQL schema names after the failed restore.


Made with [Cursor](https://cursor.com)